### PR TITLE
Tidy up atests

### DIFF
--- a/PythonWhiteLibrary/atests/KeywordTests.robot
+++ b/PythonWhiteLibrary/atests/KeywordTests.robot
@@ -4,6 +4,7 @@ ${TEST APPLICATION}      UIAutomationTest${/}bin${/}Debug${/}app.publish${/}UIAu
 
 *** Settings ***
 Library    OperatingSystem
+Library    String
 Library    ../src/WhiteLibrary.py
 #Library    WhiteLibrary    dev=${TRUE}
 Suite Setup    Launch App
@@ -138,20 +139,19 @@ Disable and enable screenshots on failure
 
 Switch Tab
     Select Tab Page    tabControl    Tab2
+    Verify Label    selectionIndicatorLabel    nothing selected
     [Teardown]    Select Tab Page    tabControl    Tab1
 
 Handle Tree Nodes
-    [Setup]    Run Keywords    Attach Main Window    AND    Select Tab Page    tabControl    Tab2
-    @{node 1} =    Create List    Tree node 1
-    @{node 2} =    Create List    Tree node 1    Tree node 1.1
-    Select Tree Node    tree    @{node 1}
-    Verify Label    selectionIndicatorLabel    Tree node 1 selected
-    Expand Tree Node    tree    @{node 1}
-    Verify Label    selectionIndicatorLabel    Tree node 1 expanded
-    Double Click Tree Node    tree    @{node 1}
-    Verify Label    selectionIndicatorLabel    Tree node 1 double-clicked
-    Right Click Tree Node    tree    @{node 2}
-    Verify Label    selectionIndicatorLabel    Tree node 1.1 right-clicked
+    [Setup]    Setup for Tab 2 Tests
+    Select Tree Node    tree    @{Tree node 1}
+    Tree node 1 Should Be Selected
+    Expand Tree Node    tree    @{Tree node 1}
+    Tree node 1 Should Be Expanded
+    Double Click Tree Node    tree    @{Tree node 1}
+    Tree node 1 Should Be Double-clicked
+    Right Click Tree Node    tree    @{Tree node 1.1}
+    Tree node 1.1 Should Be Right-clicked
     [Teardown]    Select Tab Page    tabControl    Tab1
 
 Right Click An Item
@@ -205,3 +205,16 @@ New Screenshot Should Be Created
 New Screenshot Should Not Be Created
     ${new_count}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
     Should Be Equal    ${new_count}    ${COUNT}
+
+Setup For Tab 2 Tests
+    Attach Main Window
+    Select Tab Page    tabControl    Tab2
+    @{Tree node 1} =    Create List    Tree node 1
+    @{Tree node 1.1} =    Create List    Tree node 1    Tree node 1.1
+    Set Test Variable    @{Tree node 1}
+    Set Test Variable    @{Tree node 1.1}
+
+${node label} Should Be ${status}
+    [Documentation]    Note that node label is case sensitive
+    ${status}=    Convert To Lowercase    ${status}
+    Verify Label    selectionIndicatorLabel    ${node label} ${status}

--- a/PythonWhiteLibrary/atests/KeywordTests.robot
+++ b/PythonWhiteLibrary/atests/KeywordTests.robot
@@ -116,30 +116,25 @@ Calculate Using Index Locators
     Verify Text In Textbox    index=3    3
 
 Take screenshots
-    ${count_1}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
+    [Setup]    Screenshot Setup
     Take Desktop Screenshot
-    ${count_2}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
-    Should Be True    ${count_2} > ${count_1}
+    New Screenshot Should Be Created
     Take Desktop Screenshot
-    ${count_3}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
-    Should Be True    ${count_3} > ${count_2}
+    New Screenshot Should Be Created
 
 Take screenshot on failure
-    ${count_1}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
-    Run Keyword And Expect Error    *    Verify Text In Textbox    index=3    3
-    ${count_2}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
-    Should Be True    ${count_2} > ${count_1}
+    [Setup]    Screenshot Setup
+    Run Keyword And Expect Error    *    Should Be True    ${FALSE}
+    New Screenshot Should Be Created
 
 Disable and enable screenshots on failure
-    ${count_1}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
+    [Setup]    Screenshot Setup
     Take Screenshots On Failure    false
-    Run Keyword And Expect Error    *    Verify Text In Textbox    index=3    3
-    ${count_2}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
-    Should Be Equal    ${count_2}    ${count_1}
+    Run Keyword And Expect Error    *    Should Be True    ${FALSE}
+    New Screenshot Should Not Be Created
     Take Screenshots On Failure    ${True}
-    Run Keyword And Expect Error    *    Verify Text In Textbox    index=3    3
-    ${count_3}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
-    Should Be True    ${count_3} > ${count_2}
+    Run Keyword And Expect Error    *    Should Be True    ${FALSE}
+    New Screenshot Should Be Created
 
 Switch Tab
     Select Tab Page    tabControl    Tab2
@@ -196,3 +191,17 @@ Calculate ${num1} ${operator} ${num2} Equals ${result}
     Input Text To Textbox    txtB    ${num2}
     Click Button    btnCalc
     Verify Text In Textbox    tbResult    ${result}
+
+Screenshot Setup
+    Attach Main Window
+    ${COUNT}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
+    Set Test Variable    ${COUNT}
+
+New Screenshot Should Be Created
+    ${new_count}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
+    Should Be Equal    ${new_count}    ${COUNT+1}
+    Set Test Variable    ${COUNT}    ${new_count}
+
+New Screenshot Should Not Be Created
+    ${new_count}=    Count Files In Directory    ${OUTPUTDIR}    whitelib_screenshot_*.png
+    Should Be Equal    ${new_count}    ${COUNT}


### PR DESCRIPTION
Make tests for screenshots and tree nodes more readable