### PR TITLE
Rename argument of Input Text To Textbox keyword

### DIFF
--- a/UIAutomationTest/TestWindow.xaml
+++ b/UIAutomationTest/TestWindow.xaml
@@ -33,7 +33,7 @@
                                 <MenuItem Header="_About" Name="menuAbout" Click="menuAboutClick" Background="#FFA9D1F4"></MenuItem>
                             </MenuItem>
                         </Menu>
-                        <TextBox Height="23" Margin="0,5,0,5" Name="txtA" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1">
+                        <TextBox Height="23" Margin="0,5,0,5" Name="txtA" AutomationProperties.Name="Calc1" VerticalAlignment="Top" Grid.Column="1" Grid.Row="1">
                         </TextBox>
                         <TextBox Height="23" Margin="0,5,0,5" Name="txtB" VerticalAlignment="Top" Grid.Column="1" Grid.Row="3">
                         </TextBox>

--- a/atests/KeywordTests.robot
+++ b/atests/KeywordTests.robot
@@ -25,7 +25,8 @@ Verify Get Text From Label
 Write to Textbox
     Input Text To Textbox    txtA    Ismo
     Input Text To Textbox    txtB    Aro
-    Input Text To Textbox   passwordBox    viisi
+    Input Text To Textbox    text=Calc1    Ismo!
+    Input Text To Textbox    passwordBox    viisi
 
 Verify Text
     Input Text To Textbox     txtA    Antti

--- a/src/WhiteLibrary/keywords/items/textbox.py
+++ b/src/WhiteLibrary/keywords/items/textbox.py
@@ -5,16 +5,16 @@ from WhiteLibrary.keywords.robotlibcore import keyword
 
 class TextBoxKeywords(LibraryComponent):
     @keyword
-    def input_text_to_textbox(self, locator, text):
+    def input_text_to_textbox(self, locator, input):
         """
         Writes text to a textbox.
 
         ``locator`` is the locator of the text box.
 
-        ``text`` is the text to write.
+        ``input`` is the text to write.
         """
         textBox = self.state._get_typed_item_by_locator(TextBox, locator)
-        textBox.Text = text
+        textBox.Text = input
 
     @keyword
     def verify_text_in_textbox(self, locator, expected):


### PR DESCRIPTION
Fixes #48 

Name of the second argument caused a problem when using the "text=" locator prefix


