### PR TITLE
Use robot timestrings in arguments of configuration keywords

### DIFF
--- a/atests/KeywordTests.robot
+++ b/atests/KeywordTests.robot
@@ -15,17 +15,17 @@ Test Teardown    Clean App
 Configuration Parameters
     [Setup]    NONE
     [Teardown]    White Configuration Parameters Restore
-    Set White Busy Timeout    10000
+    Set White Busy Timeout    10
     ${BUSY_TIMEOUT}    Get White Busy Timeout
-    Should Be Equal   ${BUSY_TIMEOUT}	${10000}
+    Should Be Equal   ${BUSY_TIMEOUT}    10000 milliseconds
 
-    Set White Find Window Timeout    10000
+    Set White Find Window Timeout    10 s
     ${WHITE FIND WINDOW_TIMEOUT}    Get White Find Window Timeout
-    Should Be Equal    ${WHITE FIND WINDOW_TIMEOUT}    ${10000}
+    Should Be Equal    ${WHITE FIND WINDOW_TIMEOUT}    10000 milliseconds
 
-    Set White Double Click Interval    50
+    Set White Double Click Interval    0.05 seconds
     ${WHITE_DOUBLE_CLICK_INTERVAL}    Get White Double Click Interval
-    Should Be Equal    ${WHITE_DOUBLE_CLICK_INTERVAL}    ${50}
+    Should Be Equal    ${WHITE_DOUBLE_CLICK_INTERVAL}    50 milliseconds
 
 
 Verify Labels
@@ -396,6 +396,6 @@ ${node label} Should Be ${status}
 
 White Configuration Parameters Restore
     #These defaults are defined in White Stack source code.
-    Set White Busy Timeout    5000
-    Set White Find Window Timeout    30000
-    Set White Double Click Interval    0
+    Set White Busy Timeout    5000 ms
+    Set White Find Window Timeout    30000 ms
+    Set White Double Click Interval    0 ms

--- a/src/WhiteLibrary/keywords/configuration.py
+++ b/src/WhiteLibrary/keywords/configuration.py
@@ -3,7 +3,7 @@ from TestStack.White.UIItems import DateFormat
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from robot.api import logger
-from robot.utils import robottime
+from robot.utils import timestr_to_secs
 
 
 class WhiteConfigurationKeywords(LibraryComponent):
@@ -61,7 +61,7 @@ class WhiteConfigurationKeywords(LibraryComponent):
         return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.DoubleClickInterval)
 
     def _get_timestr_in_milliseconds(self, time_string):
-        return robottime.timestr_to_secs(time_string) * 1000
+        return timestr_to_secs(time_string) * 1000
 
     def _get_milliseconds_as_timestr(self, milliseconds):
         return "{} milliseconds".format(milliseconds)

--- a/src/WhiteLibrary/keywords/configuration.py
+++ b/src/WhiteLibrary/keywords/configuration.py
@@ -3,60 +3,65 @@ from TestStack.White.UIItems import DateFormat
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from robot.api import logger
+from robot.utils import robottime
 
 
 class WhiteConfigurationKeywords(LibraryComponent):
-
     @keyword
-    def set_white_busy_timeout(self, value):
-        """Sets busy timeout for White Teststack
+    def set_white_busy_timeout(self, timeout):
+        """Sets BusyTimeout for White and returns original value.
 
-        ``value`` is integer or timeout in milli seconds. Default is 5000.
+        ``timeout`` is the timeout value as Robot time string.
 
+         Default timeout is 5 seconds.
         """
-
-        CoreAppXmlConfiguration.Instance.BusyTimeout = int(value)
+        CoreAppXmlConfiguration.Instance.BusyTimeout = self._get_timestr_in_milliseconds(timeout)
         logger.info("White Busy Timeout set to" + str(CoreAppXmlConfiguration.Instance.BusyTimeout))
-        return CoreAppXmlConfiguration.Instance.BusyTimeout
+        return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.BusyTimeout)
+
     @keyword
     def get_white_busy_timeout(self):
-        """Gets busy timeout for White Teststack
-
-        """
-        return CoreAppXmlConfiguration.Instance.BusyTimeout
+        """Returns BusyTimeout value of White."""
+        return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.BusyTimeout)
 
     @keyword
-    def set_white_find_window_timeout(self, value):
-        """Sets find window timeout for White Teststack
+    def set_white_find_window_timeout(self, timeout):
+        """Sets FindWindowTimeout for White and returns original value.
 
-        ``value`` is integer or timeout in milli seconds. Default is 30000.
+        ``timeout`` is the timeout value as Robot time string.
 
+        Default timeout is 30 seconds.
         """
-
-        CoreAppXmlConfiguration.Instance.FindWindowTimeout = int(value)
+        CoreAppXmlConfiguration.Instance.FindWindowTimeout = self._get_timestr_in_milliseconds(timeout)
         logger.info("White FindWindowTimeout set to" + str(CoreAppXmlConfiguration.Instance.FindWindowTimeout))
-        return CoreAppXmlConfiguration.Instance.FindWindowTimeout
+        return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.FindWindowTimeout)
+
     @keyword
     def get_white_find_window_timeout(self):
-        """Gets white find window timeout for White Teststack
-
-        """
-        return CoreAppXmlConfiguration.Instance.FindWindowTimeout
+        """Returns FindWindowTimeout value of White."""
+        return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.FindWindowTimeout)
 
     @keyword
-    def set_white_double_click_interval(self, value):
-        """Sets DoubleClickInterval for White Teststack
+    def set_white_double_click_interval(self, interval):
+        """Sets DoubleClickInterval for White and returns original value.
 
-        ``value`` is integer. DoubleClickInterval adds delay in double click action between clicks. Value is milliseconds. Default value is 0.
+        DoubleClickInterval adds delay in double click action between clicks.
 
+        ``interval`` is the interval value as Robot time string.
+
+        Default interval is 0 milliseconds.
         """
+        CoreAppXmlConfiguration.Instance.DoubleClickInterval = self._get_timestr_in_milliseconds(interval)
+        logger.info("White DoubleClickInterval set to" + str(CoreAppXmlConfiguration.Instance.DoubleClickInterval))
+        return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.DoubleClickInterval)
 
-        CoreAppXmlConfiguration.Instance.DoubleClickInterval = int(value)
-        logger.info("White MaxElementSearchDepth set to" + str(CoreAppXmlConfiguration.Instance.DoubleClickInterval))
-        return CoreAppXmlConfiguration.Instance.DoubleClickInterval
     @keyword
     def get_white_double_click_interval(self):
-        """Gets DoubleClickInterval for White Teststack
+        """Returns DoubleClickInterval value of White."""
+        return self._get_milliseconds_as_timestr(CoreAppXmlConfiguration.Instance.DoubleClickInterval)
 
-        """
-        return CoreAppXmlConfiguration.Instance.DoubleClickInterval
+    def _get_timestr_in_milliseconds(self, time_string):
+        return robottime.timestr_to_secs(time_string) * 1000
+
+    def _get_milliseconds_as_timestr(self, milliseconds):
+        return "{} milliseconds".format(milliseconds)


### PR DESCRIPTION
`Get` config value keywords now also return the value as robot
timestring ('x milliseconds').


