### PR TITLE
New and renamed keywords for ListView

### DIFF
--- a/UIAutomationTest/TestWindow.xaml
+++ b/UIAutomationTest/TestWindow.xaml
@@ -154,6 +154,11 @@
                                       ItemsSource="{Binding Mode=Default, XPath=/MockObjects/MockObject}"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True">
+                                <DataGrid.Resources>
+                                    <Style TargetType="DataGridRow">
+                                        <EventSetter Event="MouseDoubleClick" Handler="datagridRowDoubleClick"/>
+                                    </Style>
+                                </DataGrid.Resources>
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Title" Binding="{Binding XPath=@Title}" Width="*" />
                                 </DataGrid.Columns>
@@ -173,6 +178,11 @@
                                       ItemsSource="{Binding Mode=Default, XPath=/MockObjects/MockObject}"
                                       AutoGenerateColumns="False"
                                       IsReadOnly="True">
+                                <DataGrid.Resources>
+                                    <Style TargetType="DataGridRow">
+                                        <EventSetter Event="MouseDoubleClick" Handler="datagridRowDoubleClick"/>
+                                    </Style>
+                                </DataGrid.Resources>
                                 <DataGrid.Columns>
                                     <DataGridTextColumn Header="Author" Binding="{Binding XPath=@Author}" Width="Auto" />
                                     <DataGridTextColumn Header="Title" Binding="{Binding XPath=@Title}" Width="Auto" />

--- a/UIAutomationTest/TestWindow.xaml
+++ b/UIAutomationTest/TestWindow.xaml
@@ -3,8 +3,8 @@
     xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
     Title="UI Automation Test Window" Height="750" WindowStartupLocation="CenterScreen">
     <Window.Resources>
-        <XmlDataProvider x:Key="MockList"   XPath="/MockObjects/*" >
-            <x:XData >
+        <XmlDataProvider x:Key="MockList" XPath="/MockObjects/*" >
+            <x:XData>
                 <MockObjects xmlns="">
                     <MockObject Title="Robinson Crusoe" />
                     <MockObject Title="Bible" />
@@ -12,8 +12,8 @@
                 </MockObjects>
             </x:XData>
         </XmlDataProvider>
-        <XmlDataProvider x:Key="MockList2"   XPath="/MockObjects/*" >
-            <x:XData >
+        <XmlDataProvider x:Key="MockList2" XPath="/MockObjects/*" >
+            <x:XData>
                 <MockObjects xmlns="">
                     <MockObject Author="Daniel Defoe" Title="Robinson Crusoe" Category="Fiction"/>
                     <MockObject Author="Various Artists" Title="Bible" Category="Religious" />
@@ -21,8 +21,17 @@
                 </MockObjects>
             </x:XData>
         </XmlDataProvider>
+        <XmlDataProvider x:Key="BirdList" XPath="/MockObjects/*" >
+            <x:XData>
+                <MockObjects xmlns="">
+                    <MockObject Name="Budgerigar" Scientific="Melopsittacus undulatus"/>
+                    <MockObject Name="Common raven" Scientific="Corvus corax"/>
+                    <MockObject Name="Dodo" Scientific="Raphus cucullatus"/>
+                </MockObjects>
+            </x:XData>
+        </XmlDataProvider>
     </Window.Resources>
-    <Grid Margin="0,0,-5,0">
+    <Grid>
         <Grid.Resources>
             <Style TargetType="{x:Type TreeViewItem}">
                 <EventSetter Event="Selected" Handler="treeNodeSelect"/>
@@ -30,13 +39,10 @@
                 <EventSetter Event="MouseRightButtonDown" Handler="treeNodeRightClick"/>
                 <EventSetter Event="Expanded" Handler="treeNodeExpanded"/>
             </Style>
-            <Style TargetType="{x:Type DataGridCell}">
-                <EventSetter Event="MouseRightButtonDown" Handler="dataGridCellRightClick"/>
-                <EventSetter Event="Selected" Handler="dataGridCellSelect"/>
-            </Style>
         </Grid.Resources>
+        
         <ScrollViewer>
-            <TabControl AutomationProperties.AutomationId="tabControl" Grid.ColumnSpan="2" Margin="0,0,0,0.2">
+            <TabControl AutomationProperties.AutomationId="tabControl" Grid.ColumnSpan="2">
                 <TabItem Header="Tab1">
                     <StackPanel>
                         <Grid>
@@ -140,10 +146,10 @@
                     </StackPanel>
                 </TabItem>
                 <TabItem Header="Tab2">
-                    <StackPanel Orientation="Vertical">
+                    <StackPanel>
                         <Label Name="selectionIndicatorLabel">nothing selected</Label>
                         <Label Name="cursorPosition"
-                               MouseMove="cursorPositionShow"></Label>
+                               MouseMove="cursorPositionShow">move mouse</Label>
                         <ToolBar AutomationProperties.AutomationId="tools">
                             <Button Click="toolStripButtonClick">Toolstrip button 1</Button>
                             <Button Click="toolStripButtonClick">Toolstrip button 2</Button>
@@ -157,6 +163,8 @@
                                 <DataGrid.Resources>
                                     <Style TargetType="DataGridRow">
                                         <EventSetter Event="MouseDoubleClick" Handler="datagridRowDoubleClick"/>
+                                        <EventSetter Event="MouseRightButtonUp" Handler="dataGridRowRightClick"/>
+                                        <EventSetter Event="Selected" Handler="dataGridRowSelect"/>
                                     </Style>
                                 </DataGrid.Resources>
                                 <DataGrid.Columns>
@@ -177,20 +185,23 @@
                             <DataGrid AutomationProperties.AutomationId="list_view2" 
                                       ItemsSource="{Binding Mode=Default, XPath=/MockObjects/MockObject}"
                                       AutoGenerateColumns="False"
-                                      IsReadOnly="True">
+                                      IsReadOnly="True"
+                                      SelectionUnit="Cell">
                                 <DataGrid.Resources>
-                                    <Style TargetType="DataGridRow">
-                                        <EventSetter Event="MouseDoubleClick" Handler="datagridRowDoubleClick"/>
+                                    <Style TargetType="{x:Type DataGridCell}">
+                                        <EventSetter Event="MouseRightButtonUp" Handler="dataGridCellRightClick"/>
+                                        <EventSetter Event="MouseDoubleClick" Handler="dataGridCellDoubleClick"/>
+                                        <EventSetter Event="Selected" Handler="dataGridCellSelect"/>
                                     </Style>
                                 </DataGrid.Resources>
                                 <DataGrid.Columns>
-                                    <DataGridTextColumn Header="Author" Binding="{Binding XPath=@Author}" Width="Auto" />
-                                    <DataGridTextColumn Header="Title" Binding="{Binding XPath=@Title}" Width="Auto" />
-                                    <DataGridTextColumn Header="Category" Binding="{Binding XPath=@Category}" Width="Auto" />
+                                    <DataGridTextColumn Header="Author" Binding="{Binding XPath=@Author}" Width="*" />
+                                    <DataGridTextColumn Header="Title" Binding="{Binding XPath=@Title}" Width="*" />
+                                    <DataGridTextColumn Header="Category" Binding="{Binding XPath=@Category}" Width="*" />
                                 </DataGrid.Columns>
                             </DataGrid>
                         </Grid>
-                        <TreeView AutomationProperties.AutomationId="tree" Margin="0,0,0,0" Height="Auto">
+                        <TreeView AutomationProperties.AutomationId="tree">
                             <TreeViewItem Header="Tree node 1">
                                 <TreeViewItem Header="Tree node 1.1" />
                                 <TreeViewItem Header="Tree node 1.2">
@@ -198,7 +209,7 @@
                                 </TreeViewItem>
                             </TreeViewItem>
                         </TreeView>
-                        <Grid Height="Auto" Margin="0,10,0,10">
+                        <Grid Height="Auto">
                             <Grid.ColumnDefinitions>
                                 <ColumnDefinition Width="100"></ColumnDefinition>
                                 <ColumnDefinition Width="100"></ColumnDefinition>
@@ -224,6 +235,25 @@
                                     >
                             </Button>
                         </Grid>
+                        <DockPanel>
+                            <DataGrid DataContext="{Binding Source={StaticResource BirdList}}"
+                                      AutomationProperties.AutomationId="birds" 
+                                      ItemsSource="{Binding Mode=Default, XPath=/MockObjects/MockObject}"
+                                      AutoGenerateColumns="False"
+                                      IsReadOnly="True">
+                                <DataGrid.Resources>
+                                    <Style TargetType="DataGridRow">
+                                        <EventSetter Event="MouseDoubleClick" Handler="datagridRowDoubleClick"/>
+                                        <EventSetter Event="MouseRightButtonUp" Handler="dataGridRowRightClick"/>
+                                        <EventSetter Event="Selected" Handler="dataGridRowSelect"/>
+                                    </Style>
+                                </DataGrid.Resources>
+                                <DataGrid.Columns>
+                                    <DataGridTextColumn Header="Bird" Binding="{Binding XPath=@Name}" Width="100" />
+                                    <DataGridTextColumn Header="Scientific name" Binding="{Binding XPath=@Scientific}" Width="*" />
+                                </DataGrid.Columns>
+                            </DataGrid>
+                        </DockPanel>
                     </StackPanel>
                 </TabItem>
             </TabControl>

--- a/UIAutomationTest/TestWindow.xaml.cs
+++ b/UIAutomationTest/TestWindow.xaml.cs
@@ -91,8 +91,6 @@ namespace UIAutomationTest
             MessageBox.Show(text, title, button);
         }
 
-        
-
         private void treeNodeSelect(object sender, RoutedEventArgs e)
         {
             treeNodeEvent(sender, e, "selected");
@@ -142,8 +140,23 @@ namespace UIAutomationTest
 
         private void datagridRowDoubleClick(object sender, RoutedEventArgs e)
         {
+            dataGridRowEvent(sender, "double clicked");
+        }
+
+        private void dataGridRowSelect(object sender, RoutedEventArgs e)
+        {
+            dataGridRowEvent(sender, "selected");
+        }
+
+        private void dataGridRowRightClick(object sender, RoutedEventArgs e)
+        {
+            dataGridRowEvent(sender, "right clicked");
+        }
+
+        private void dataGridRowEvent(object sender, string message)
+        {
             DataGridRow row = sender as DataGridRow;
-            MessageBox.Show("Double clicked row " + row.GetIndex().ToString());
+            selectionIndicatorLabel.Content = "Row " + row.GetIndex().ToString() + " " + message;
         }
 
         private void popupItemClick(object sender, RoutedEventArgs e)
@@ -178,7 +191,7 @@ namespace UIAutomationTest
             TextBlock cellText = node.Content as TextBlock;
             if (node != null)
             {
-                selectionIndicatorLabel.Content = cellText.Text + " " + message;
+              selectionIndicatorLabel.Content = cellText.Text + " " + message;
             }
             e.Handled = true;
 
@@ -195,8 +208,7 @@ namespace UIAutomationTest
             await TaskEx.Delay(5000);
             selectionIndicatorLabel.Content = "Slow alert occurred";
         }
-
-
+        
         private void eventLabelRightDown(object sender, RoutedEventArgs e)
         {
             labelEvent(sender, e, "right button down");
@@ -225,8 +237,7 @@ namespace UIAutomationTest
         {
             selectionIndicatorLabel.Content = message;
         }
-
-
+        
         private void eventTestButtonRightClick(object sender, RoutedEventArgs e)
         {
             testButtonEvent(sender, e, "right clicked");
@@ -249,6 +260,5 @@ namespace UIAutomationTest
             Point pnt = e.GetPosition(this);
             cursorPosition.Content = pnt.ToString();
         }
-
     }
 }

--- a/UIAutomationTest/TestWindow.xaml.cs
+++ b/UIAutomationTest/TestWindow.xaml.cs
@@ -140,6 +140,12 @@ namespace UIAutomationTest
 
         }
 
+        private void datagridRowDoubleClick(object sender, RoutedEventArgs e)
+        {
+            DataGridRow row = sender as DataGridRow;
+            MessageBox.Show("Double clicked row " + row.GetIndex().ToString());
+        }
+
         private void popupItemClick(object sender, RoutedEventArgs e)
         {
             MessageBox.Show("Delete not allowed");

--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -72,7 +72,7 @@ Get Text From ListView
     ${actual}    Get Listview Cell Text By Index    list_view2    2    2
     Should Be Equal    ${actual}    Science
 
-ListView Select
+Select Listview Row
     Select ListView Row By Index    list_view    1
     Bible Should Be Selected
     Select ListView Row By Index    list_view    2
@@ -80,8 +80,17 @@ ListView Select
     Select ListView Row    list_view    Title    Robinson Crusoe
     Robinson Crusoe Should Be Selected
 
-ListView Right Click
+Right Click Listview Cell
     Repeat Keyword    2    Right Click Listview Cell    list_view2    Title    1
     Bible Should Be Right Clicked
     Repeat Keyword    2    Right Click Listview Cell    list_view2    Author    0
     Daniel Defoe Should Be Right Clicked
+
+Double Click Listview Row
+    Double Click ListView Row    list_view2    Author    Donald Knuth
+    Verify Label    65535    Double clicked row 2
+    Click Button    text=OK
+
+    Double Click ListView Row By Index    list_view2    1
+    Verify Label    65535    Double clicked row 1
+    [Teardown]    Click Button    text=OK

--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -96,7 +96,7 @@ Right Click Listview Row
 Right Click Listview Cell
     Repeat Keyword    2    Right Click Listview Cell    list_view2    Title    1
     Bible Should Be Right Clicked
-    Repeat Keyword    2    Right Click Listview Cell    list_view2    Author    0
+    Repeat Keyword    2    Right Click Listview Cell By Index    list_view2    0    0
     Daniel Defoe Should Be Right Clicked
 
 Double Click Listview Row

--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -73,12 +73,25 @@ Get Text From ListView
     Should Be Equal    ${actual}    Science
 
 Select Listview Row
-    Select ListView Row By Index    list_view    1
-    Bible Should Be Selected
+    Select ListView Row By Index    birds    1
+    Row 1 Should Be Selected
     Select ListView Row By Index    list_view    2
-    The Art of Computer Programming Should Be Selected
+    Row 2 Should Be Selected
     Select ListView Row    list_view    Title    Robinson Crusoe
-    Robinson Crusoe Should Be Selected
+    Row 0 Should Be Selected
+
+Select Listview Cell
+    Select Listview Cell    list_view2    Author    1
+    Various Artists Should Be Selected
+    Select Listview Cell By Index    list_view2    2    2
+    Science Should Be Selected
+
+Right Click Listview Row
+    # click twice because first click selects the row
+    Repeat Keyword    2    Right Click Listview Row    birds    Bird    Dodo
+    Row 2 Should Be Right Clicked
+    Repeat Keyword    2    Right Click Listview Row By Index    birds    0
+    Row 0 Should Be Right Clicked
 
 Right Click Listview Cell
     Repeat Keyword    2    Right Click Listview Cell    list_view2    Title    1
@@ -87,10 +100,13 @@ Right Click Listview Cell
     Daniel Defoe Should Be Right Clicked
 
 Double Click Listview Row
-    Double Click ListView Row    list_view2    Author    Donald Knuth
-    Verify Label    65535    Double clicked row 2
-    Click Button    text=OK
+    Double Click ListView Row    birds    Bird    Dodo
+    Row 2 Should Be Double Clicked
+    Double Click ListView Row By Index    birds    1
+    Row 1 Should Be Double Clicked
 
-    Double Click ListView Row By Index    list_view2    1
-    Verify Label    65535    Double clicked row 1
-    [Teardown]    Click Button    text=OK
+Double Click Listview Cell
+    Double Click Listview Cell    list_view2    Author    2
+    Donald Knuth Should Be Double Clicked
+    Double Click Listview Cell By Index    list_view2    0    2
+    Fiction Should Be Double Clicked

--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -8,19 +8,19 @@ Suite Teardown    Select Tab Page    tabControl    Tab1
 Row Verification
     Listview Row Should Contain    list_view2    Title    Bible    ligious
     Listview Row Should Not Contain    list_view2    Title    Robinson Crusoe    Scienc
-    Listview Row In Index Should Contain    list_view2    2    Programming
-    Listview Row In Index Should Not Contain    list_view2    1    Donald
+    Listview Row At Index Should Contain    list_view2    2    Programming
+    Listview Row At Index Should Not Contain    list_view2    1    Donald
 
 Cell Verification
     Listview Cell Text Should Be    list_view2    Title    2    The Art of Computer Programming
     Listview Cell Text Should Not Be    list_view2    Title    2    Robinson Crusoe
-    Listview Cell Text In Index Should Be   list_view2    2    1    The Art of Computer Programming
-    Listview Cell Text In Index Should Not Be    list_view2    2    1    Robinson Crusoe
+    Listview Cell Text At Index Should Be   list_view2    2    1    The Art of Computer Programming
+    Listview Cell Text At Index Should Not Be    list_view2    2    1    Robinson Crusoe
 
     Listview Cell Should Contain    list_view2    Title    2    omputer P
     Listview Cell Should Not Contain    list_view2    Title    2    obinson
-    Listview Cell In Index Should Contain    list_view2    2    1    omputer
-    Listview Cell In Index Should Not Contain    list_view2    2    1    obinson
+    Listview Cell At Index Should Contain    list_view2    2    1    omputer
+    Listview Cell At Index Should Not Contain    list_view2    2    1    obinson
 
 Unsuccessful Row Verification
     Run Keyword And Expect Error    Row defined by cell 'Title'='Bible' did not contain text 'abcd'
@@ -28,9 +28,9 @@ Unsuccessful Row Verification
     Run Keyword And Expect Error    Row defined by cell 'Title'='Robinson Crusoe' should not have contained text 'Fiction'
     ...                             Listview Row Should Not Contain    list_view2    Title    Robinson Crusoe    Fiction
     Run Keyword And Expect Error    Row 2 did not contain text 'abcd'
-    ...                             Listview Row In Index Should Contain    list_view2    2    abcd
+    ...                             Listview Row At Index Should Contain    list_view2    2    abcd
     Run Keyword And Expect Error    Row 1 should not have contained text 'igious'
-    ...                             Listview Row In Index Should Not Contain    list_view2    1    igious
+    ...                             Listview Row At Index Should Not Contain    list_view2    1    igious
 
 Unsuccessful Cell Verification
     Run Keyword And Expect Error    Cell text should have been 'Hello', found 'The Art of Computer Programming'
@@ -40,10 +40,10 @@ Unsuccessful Cell Verification
     ...                             Listview Cell Text Should Not Be    list_view2    Title    2    The Art of Computer Programming
 
     Run Keyword And Expect Error    Cell (2, 1) text should have been 'Hello', found 'The Art of Computer Programming'
-    ...                             Listview Cell Text In Index Should Be   list_view2    2    1    Hello
+    ...                             Listview Cell Text At Index Should Be   list_view2    2    1    Hello
 
     Run Keyword And Expect Error    Cell (2, 1) text should not have been 'The Art of Computer Programming'
-    ...                             Listview Cell Text In Index Should Not Be    list_view2    2    1    The Art of Computer Programming
+    ...                             Listview Cell Text At Index Should Not Be    list_view2    2    1    The Art of Computer Programming
 
     Run Keyword And Expect Error    Cell did not contain text 'obinson'
     ...                             Listview Cell Should Contain    list_view2    Title    2    obinson
@@ -52,10 +52,10 @@ Unsuccessful Cell Verification
     ...                             Listview Cell Should Not Contain    list_view2    Title    2    omputer
 
     Run Keyword And Expect Error    Cell (2, 1) did not contain text 'obinson'
-    ...                             Listview Cell In Index Should Contain    list_view2    2    1    obinson
+    ...                             Listview Cell At Index Should Contain    list_view2    2    1    obinson
 
     Run Keyword And Expect Error    Cell (2, 1) should not have contained text 'omputer'
-    ...                             Listview Cell In Index Should Not Contain    list_view2    2    1    omputer
+    ...                             Listview Cell At Index Should Not Contain    list_view2    2    1    omputer
 
 Get Text From ListView
     ${expected}    Create List    Donald Knuth    The Art of Computer Programming    Science

--- a/src/WhiteLibrary/keywords/configuration.py
+++ b/src/WhiteLibrary/keywords/configuration.py
@@ -64,19 +64,18 @@ class WhiteConfigurationKeywords(LibraryComponent):
     def set_white_drag_step_count(self, value):
         """Sets DragStepCount for White
 
-        ``value`` is integer. DragStepCount defines how many steps White Teststack uses to move dragged object to the destination.
+        ``value`` is the DragStepCount value as integer.
+
+        DragStepCount defines how many steps White uses to move dragged object to the destination.
         With default value 1 the dragged object is moved instantly in a single step from start to destination.
-
         """
-
         CoreAppXmlConfiguration.Instance.DragStepCount = int(value)
         logger.info("White DragStepCount set to" + str(CoreAppXmlConfiguration.Instance.DragStepCount))
         return CoreAppXmlConfiguration.Instance.DragStepCount
+
     @keyword
     def get_white_drag_step_count(self):
-        """Gets DragStepCount for White Teststack
-
-        """
+        """Returns DragStepCount value of White."""
         return CoreAppXmlConfiguration.Instance.DragStepCount
 
     def _get_timestr_in_milliseconds(self, time_string):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -5,6 +5,24 @@ from WhiteLibrary.keywords.robotlibcore import keyword
 
 class ListViewKeywords(LibraryComponent):
     @keyword
+    def double_click_listview_row(self, locator, column_name, cell_text):
+        """Double clicks a listview row.
+
+        See `Get Listview Row Text` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
+        """
+        row = self._get_row(locator, column_name, cell_text)
+        row.DoubleClick()
+
+    @keyword
+    def double_click_listview_row_by_index(self, locator, row_index):
+        """Double clicks a listview row at index.
+
+        See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
+        """
+        row = self._get_row_by_index(locator, row_index)
+        row.DoubleClick()
+
+    @keyword
     def get_listview_cell_text(self, locator, column_name, row_index):
         """Returns text of a listview cell.
 

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -52,7 +52,7 @@ class ListViewKeywords(LibraryComponent):
 
     @keyword
     def get_listview_cell_text_by_index(self, locator, row_index, column_index):
-        """Returns text of a listview cell.
+        """Returns text of a listview cell at index.
 
         ``locator`` is the locator of the listview.
 
@@ -243,6 +243,12 @@ class ListViewKeywords(LibraryComponent):
         cell.RightClick()
 
     @keyword
+    def right_click_listview_cell_by_index(self, locator, row_index, column_index):
+        """Right clicks a listview cell at index."""
+        cell = self._get_cell_by_index(locator, row_index, column_index)
+        cell.RightClick()
+
+    @keyword
     def right_click_listview_row(self, locator, column_name, cell_text):
         """Right clicks a listview row that has given text in given column.
 
@@ -253,12 +259,24 @@ class ListViewKeywords(LibraryComponent):
 
     @keyword
     def right_click_listview_row_by_index(self, locator, row_index):
-        """Right clicks a listview row by its index.
+        """Right clicks a listview row at index.
 
         See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
         row.RightClick()
+
+    @keyword
+    def select_listview_cell(self, locator, column_name, row_index):
+        """Selects a listview cell."""
+        cell = self._get_cell(locator, column_name, row_index)
+        cell.Click()
+
+    @keyword
+    def select_listview_cell_by_index(self, locator, row_index, column_index):
+        """Selects a listview cell at index."""
+        cell = self._get_cell_by_index(locator, row_index, column_index)
+        cell.Click()
 
     @keyword
     def select_listview_row(self, locator, column_name, cell_text):
@@ -271,7 +289,7 @@ class ListViewKeywords(LibraryComponent):
 
     @keyword
     def select_listview_row_by_index(self, locator, row_index):
-        """Selects a row from a listview.
+        """Selects a listview row at index.
 
         See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
         """

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -6,37 +6,7 @@ from WhiteLibrary.keywords.robotlibcore import keyword
 class ListViewKeywords(LibraryComponent):
     @keyword
     def double_click_listview_cell(self, locator, column_name, row_index):
-        """Double clicks a listview cell."""
-        cell = self._get_cell(locator, column_name, row_index)
-        cell.DoubleClick()
-
-    @keyword
-    def double_click_listview_cell_by_index(self, locator, row_index, column_index):
-        """Double clicks a listview cell at index."""
-        cell = self._get_cell_by_index(locator, row_index, column_index)
-        cell.DoubleClick()
-
-    @keyword
-    def double_click_listview_row(self, locator, column_name, cell_text):
-        """Double clicks a listview row.
-
-        See `Get Listview Row Text` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
-        """
-        row = self._get_row(locator, column_name, cell_text)
-        row.DoubleClick()
-
-    @keyword
-    def double_click_listview_row_by_index(self, locator, row_index):
-        """Double clicks a listview row at index.
-
-        See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
-        """
-        row = self._get_row_by_index(locator, row_index)
-        row.DoubleClick()
-
-    @keyword
-    def get_listview_cell_text(self, locator, column_name, row_index):
-        """Returns text of a listview cell.
+        """Double clicks a listview cell.
 
         ``locator`` is the locator of the listview.
 
@@ -45,14 +15,14 @@ class ListViewKeywords(LibraryComponent):
         ``row_index`` is the zero-based row index.
 
         Example:
-        | ${cell_text} | Get Listview Cell Text | id:addressList | Street | 0 | # return text in the column "Street" of the first row |
+        | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
         """
         cell = self._get_cell(locator, column_name, row_index)
-        return cell.Text
+        cell.DoubleClick()
 
     @keyword
-    def get_listview_cell_text_by_index(self, locator, row_index, column_index):
-        """Returns text of a listview cell at index.
+    def double_click_listview_cell_by_index(self, locator, row_index, column_index):
+        """Double clicks a listview cell at index.
 
         ``locator`` is the locator of the listview.
 
@@ -61,7 +31,54 @@ class ListViewKeywords(LibraryComponent):
         ``column_index`` is the zero-based column index.
 
         Example:
-        | ${cell_text} | Get Listview Cell Text By Index | id:addressList | 0 | 0 |
+        | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
+        """
+        cell = self._get_cell_by_index(locator, row_index, column_index)
+        cell.DoubleClick()
+
+    @keyword
+    def double_click_listview_row(self, locator, column_name, cell_text):
+        """Double clicks a listview row.
+
+        ``locator`` is the locator of the listview.
+
+        ``column_name`` and ``cell_text`` define the row. Row is the first matching row where text in column
+        ``column_name`` is ``cell_text``.
+
+        Example:
+        | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
+        """
+        row = self._get_row(locator, column_name, cell_text)
+        row.DoubleClick()
+
+    @keyword
+    def double_click_listview_row_by_index(self, locator, row_index):
+        """Double clicks a listview row at index.
+
+        ``locator`` is the locator of the listview.
+
+        ``row_index`` is the zero-based row index.
+
+        Example:
+        | Double Click Listview Row By Index | id:addressList | 4 |
+        """
+        row = self._get_row_by_index(locator, row_index)
+        row.DoubleClick()
+
+    @keyword
+    def get_listview_cell_text(self, locator, column_name, row_index):
+        """Returns text of a listview cell.
+
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        """
+        cell = self._get_cell(locator, column_name, row_index)
+        return cell.Text
+
+    @keyword
+    def get_listview_cell_text_by_index(self, locator, row_index, column_index):
+        """Returns text of a listview cell at index.
+
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         return cell.Text
@@ -70,13 +87,7 @@ class ListViewKeywords(LibraryComponent):
     def get_listview_row_text(self, locator, column_name, cell_text):
         """Returns a list containing text of each cell in a listview row.
 
-        ``locator`` is the locator of the listview.
-
-        ``column_name`` and ``cell_text`` define the row. Row is the first matching row where text in column
-        ``column_name`` is ``cell_text``.
-
-        Example:
-        | @{row_text} | Get Listview Row Text | id:addressList | City | Helsinki | # return all text from row that has text "Helsinki" in the column "City" |
+        See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
         return [cell.Text for cell in row.Cells]
@@ -85,21 +96,16 @@ class ListViewKeywords(LibraryComponent):
     def get_listview_row_text_by_index(self, locator, row_index):
         """Returns text of a listview row as a list.
 
-        ``locator`` is the locator of the listview.
-
-        ``row_index`` is the zero-based row index.
-
-        Example:
-        | @{row_text} | Get Listview Row Text By Index | id:addressList | 4 |
+        See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
         return [cell.Text for cell in row.Cells]
 
     @keyword
-    def listview_cell_in_index_should_contain(self, locator, row_index, column_index, expected):
+    def listview_cell_at_index_should_contain(self, locator, row_index, column_index, expected):
         """Verifies that the given listview cell contains text ``expected``.
 
-        See `Get Listview Cell Text By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         if expected not in cell.Text:
@@ -107,10 +113,10 @@ class ListViewKeywords(LibraryComponent):
                                  .format(row_index, column_index, expected))
 
     @keyword
-    def listview_cell_in_index_should_not_contain(self, locator, row_index, column_index, expected):
+    def listview_cell_at_index_should_not_contain(self, locator, row_index, column_index, expected):
         """Verifies that the given listview cell does not contain text ``expected``.
 
-        See `Get Listview Cell Text By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         if expected in cell.Text:
@@ -121,7 +127,7 @@ class ListViewKeywords(LibraryComponent):
     def listview_cell_should_contain(self, locator, column_name, row_index, expected):
         """Verifies that the given listview cell contains text ``expected``.
 
-        See `Get Listview Cell Text` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
         if expected not in cell.Text:
@@ -132,7 +138,7 @@ class ListViewKeywords(LibraryComponent):
     def listview_cell_should_not_contain(self, locator, column_name, row_index, expected):
         """Verifies that the given listview cell does not contain text ``expected``.
 
-        See `Get Listview Cell Text` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
         if expected in cell.Text:
@@ -140,10 +146,10 @@ class ListViewKeywords(LibraryComponent):
                                  .format(expected))
 
     @keyword
-    def listview_cell_text_in_index_should_be(self, locator, row_index, column_index, expected):
+    def listview_cell_text_at_index_should_be(self, locator, row_index, column_index, expected):
         """Verifies that listview cell text is ``expected``.
 
-        See `Get Listview Cell Text By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         if cell.Text != expected:
@@ -151,10 +157,10 @@ class ListViewKeywords(LibraryComponent):
                                  .format(row_index, column_index, expected, cell.Text))
 
     @keyword
-    def listview_cell_text_in_index_should_not_be(self, locator, row_index, column_index, expected):
+    def listview_cell_text_at_index_should_not_be(self, locator, row_index, column_index, expected):
         """Verifies that listview cell text is not ``expected``.
 
-        See `Get Listview Cell Text By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         if cell.Text == expected:
@@ -165,7 +171,7 @@ class ListViewKeywords(LibraryComponent):
     def listview_cell_text_should_be(self, locator, column_name, row_index, expected):
         """Verifies that listview cell text is ``expected``.
 
-        See `Get Listview Cell Text` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
         if cell.Text != expected:
@@ -175,7 +181,7 @@ class ListViewKeywords(LibraryComponent):
     def listview_cell_text_should_not_be(self, locator, column_name, row_index, expected):
         """Verifies that listview cell text is not ``expected``.
 
-        See `Get Listview Cell Text` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
         if cell.Text == expected:
@@ -183,10 +189,10 @@ class ListViewKeywords(LibraryComponent):
                                  .format(expected))
 
     @keyword
-    def listview_row_in_index_should_contain(self, locator, row_index, expected):
+    def listview_row_at_index_should_contain(self, locator, row_index, expected):
         """Verifies that any cell in the given listview row contains text ``expected``.
 
-        See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
+        See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
         for cell in row.Cells:
@@ -196,10 +202,10 @@ class ListViewKeywords(LibraryComponent):
                              .format(row_index, expected))
 
     @keyword
-    def listview_row_in_index_should_not_contain(self, locator, row_index, expected):
+    def listview_row_at_index_should_not_contain(self, locator, row_index, expected):
         """Verifies that any cell in the given listview row does not contain text ``expected``.
 
-        See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
+        See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         listview = self.state._get_typed_item_by_locator(ListView, locator)
         row = listview.Rows.Get(int(row_index))
@@ -212,7 +218,7 @@ class ListViewKeywords(LibraryComponent):
     def listview_row_should_contain(self, locator, column_name, cell_text, expected):
         """Verifies that the given listview row contains text ``expected``.
 
-        See `Get Listview Row Text` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
+        See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
         for cell in row.Cells:
@@ -225,7 +231,7 @@ class ListViewKeywords(LibraryComponent):
     def listview_row_should_not_contain(self, locator, column_name, cell_text, expected):
         """Verifies that the given listview row does not contain text ``expected``.
 
-        See `Get Listview Row Text` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
+        See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
         for cell in row.Cells:
@@ -237,14 +243,17 @@ class ListViewKeywords(LibraryComponent):
     def right_click_listview_cell(self, locator, column_name, row_index):
         """Right clicks a listview cell using its column name and row index.
 
-        See `Get Listview Cell Text` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
         cell.RightClick()
 
     @keyword
     def right_click_listview_cell_by_index(self, locator, row_index, column_index):
-        """Right clicks a listview cell at index."""
+        """Right clicks a listview cell at index.
+
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
+        """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         cell.RightClick()
 
@@ -252,7 +261,7 @@ class ListViewKeywords(LibraryComponent):
     def right_click_listview_row(self, locator, column_name, cell_text):
         """Right clicks a listview row that has given text in given column.
 
-        See `Get Listview Row Text` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
+        See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
         row.RightClick()
@@ -261,20 +270,26 @@ class ListViewKeywords(LibraryComponent):
     def right_click_listview_row_by_index(self, locator, row_index):
         """Right clicks a listview row at index.
 
-        See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
+        See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
         row.RightClick()
 
     @keyword
     def select_listview_cell(self, locator, column_name, row_index):
-        """Selects a listview cell."""
+        """Selects a listview cell.
+
+        See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
+        """
         cell = self._get_cell(locator, column_name, row_index)
         cell.Click()
 
     @keyword
     def select_listview_cell_by_index(self, locator, row_index, column_index):
-        """Selects a listview cell at index."""
+        """Selects a listview cell at index.
+
+        See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
+        """
         cell = self._get_cell_by_index(locator, row_index, column_index)
         cell.Click()
 
@@ -282,7 +297,7 @@ class ListViewKeywords(LibraryComponent):
     def select_listview_row(self, locator, column_name, cell_text):
         """Selects a listview row.
 
-        See `Get Listview Row Text` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
+        See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         listview = self.state._get_typed_item_by_locator(ListView, locator)
         listview.Select(column_name, cell_text)
@@ -291,7 +306,7 @@ class ListViewKeywords(LibraryComponent):
     def select_listview_row_by_index(self, locator, row_index):
         """Selects a listview row at index.
 
-        See `Get Listview Row Text By Index` for details about arguments ``locator`` and ``row_index``.
+        See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         listview = self.state._get_typed_item_by_locator(ListView, locator)
         listview.Select(int(row_index))

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -5,6 +5,18 @@ from WhiteLibrary.keywords.robotlibcore import keyword
 
 class ListViewKeywords(LibraryComponent):
     @keyword
+    def double_click_listview_cell(self, locator, column_name, row_index):
+        """Double clicks a listview cell."""
+        cell = self._get_cell(locator, column_name, row_index)
+        cell.DoubleClick()
+
+    @keyword
+    def double_click_listview_cell_by_index(self, locator, row_index, column_index):
+        """Double clicks a listview cell at index."""
+        cell = self._get_cell_by_index(locator, row_index, column_index)
+        cell.DoubleClick()
+
+    @keyword
     def double_click_listview_row(self, locator, column_name, cell_text):
         """Double clicks a listview row.
 


### PR DESCRIPTION
New keywords:
- Double Click Listview Cell
- Double Click Listview Cell By Index
- Double Click Listview Row
- Double Click Listview Row By Index 

- Right Click Listview Cell By Index

- Select Listview Cell
- Select Listview Cell By Index

Renamed multiple keywords: 
- Listview Cell In Index Should ... -> Listview Cell At Index Should ...
- Listview Row In Index Should ... -> Listview Row At Index Should ...