### PR TITLE
Click offsets

### DIFF
--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -73,7 +73,6 @@ Get Text From ListView
     Should Be Equal    ${actual}    Science
 
 Select Listview Row
-    [Tags]    do_not_run
     Select ListView Row By Index    birds    1
     Row 1 Should Be Selected
     Select ListView Row By Index    list_view    2

--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -73,6 +73,7 @@ Get Text From ListView
     Should Be Equal    ${actual}    Science
 
 Select Listview Row
+    [Tags]    do_not_run
     Select ListView Row By Index    birds    1
     Row 1 Should Be Selected
     Select ListView Row By Index    list_view    2

--- a/atests/feature_tests/mouse.robot
+++ b/atests/feature_tests/mouse.robot
@@ -54,6 +54,24 @@ Verify Mouse Click
     Sleep    2
     Verify Label    selectionIndicatorLabel    left button up
 
+Verify Mouse Click With Offset
+    [Tags]    under_test
+    Click Button    test_button    3    3
+    Sleep    2
+    Verify Label    selectionIndicatorLabel    left clicked
+
+Verify Mouse Click With Negative Offset
+    [Tags]    under_test
+    Click Button    test_button    -13    -13
+    Sleep    2
+    Verify Label    selectionIndicatorLabel    left clicked
+
+Verify Mouse Click With Out Of Bounds Offset
+    [Tags]    under_test
+    ${status}    ${error_msg}    Run Keyword And Ignore Error    Click Button    test_button    -100    -100
+    Should Contain    ${error_msg}    click location out of bounds
+
+
 Verify Mouse Right Double Click
     Click Item    event_label
     Sleep    2
@@ -70,5 +88,4 @@ Verify Mouse Double Click
 
 Verify Incomplete Mouse Position Exception
     ${status}    ${error_msg}    Run Keyword And Ignore Error    Mouse Click    300
-    ${MOUSE_X}    ${MOUSE_Y}    Get Mouse Location
     Should Contain    ${error_msg}    Either x or y value missing

--- a/atests/feature_tests/mouse.robot
+++ b/atests/feature_tests/mouse.robot
@@ -72,10 +72,21 @@ Verify Mouse Right Click With Negative Offset
     Right Click Item    event_label    -10    -10
     Verify Label    selectionIndicatorLabel    right button up
 
-Verify Mouse Click With Out Of Bounds Offset
-    ${status}    ${error_msg}    Run Keyword And Ignore Error    Click Item    event_label    -100    -100
+Verify Mouse Right Click With Out Of Bounds Offset
+    ${status}    ${error_msg}    Run Keyword And Ignore Error    Right Click Item    event_label    -100    -100
     Should Contain    ${error_msg}    click location out of bounds
 
+Verify Mouse Double Click With Offset
+    Double Click Item    event_label     3    3
+    Verify Label    selectionIndicatorLabel    left button up
+
+Verify Mouse Double Click With Negative Offset
+    Double Click Item    event_label    -10    -10
+    Verify Label    selectionIndicatorLabel    left button up
+
+Verify Mouse Double Click With Out Of Bounds Offset
+    ${status}    ${error_msg}    Run Keyword And Ignore Error    Double Click Item    event_label    -100    -100
+    Should Contain    ${error_msg}    click location out of bounds
 
 Verify Mouse Right Double Click
     Click Item    event_label

--- a/atests/feature_tests/mouse.robot
+++ b/atests/feature_tests/mouse.robot
@@ -44,46 +44,49 @@ Verify Mouse Right Click
     Click Item    event_label
     Sleep    2
     Mouse Right Click
-    Sleep    2
     Verify Label    selectionIndicatorLabel    right button up
 
 Verify Mouse Click
     Click Item    event_label
     Sleep    2
     Mouse Click
-    Sleep    2
     Verify Label    selectionIndicatorLabel    left button up
 
 Verify Mouse Click With Offset
-    [Tags]    under_test
-    Click Button    test_button    3    3
-    Sleep    2
-    Verify Label    selectionIndicatorLabel    left clicked
+    Click Item    event_label    3    3
+    Verify Label    selectionIndicatorLabel    left button up
 
 Verify Mouse Click With Negative Offset
-    [Tags]    under_test
-    Click Button    test_button    -13    -13
-    Sleep    2
-    Verify Label    selectionIndicatorLabel    left clicked
+    Click Item    event_label    -10    -10
+    Verify Label    selectionIndicatorLabel    left button up
 
 Verify Mouse Click With Out Of Bounds Offset
-    [Tags]    under_test
-    ${status}    ${error_msg}    Run Keyword And Ignore Error    Click Button    test_button    -100    -100
+    ${status}    ${error_msg}    Run Keyword And Ignore Error    Click Item    event_label    -100    -100
+    Should Contain    ${error_msg}    click location out of bounds
+
+Verify Mouse Right Click With Offset
+    Right Click Item    event_label     3    3
+    Verify Label    selectionIndicatorLabel    right button up
+
+Verify Mouse Right Click With Negative Offset
+    Right Click Item    event_label    -10    -10
+    Verify Label    selectionIndicatorLabel    right button up
+
+Verify Mouse Click With Out Of Bounds Offset
+    ${status}    ${error_msg}    Run Keyword And Ignore Error    Click Item    event_label    -100    -100
     Should Contain    ${error_msg}    click location out of bounds
 
 
 Verify Mouse Right Double Click
     Click Item    event_label
-    Sleep    2
+    Sleep    1
     Mouse Right Double Click
-    Sleep    2
     Verify Label    selectionIndicatorLabel    right button up
 
 Verify Mouse Double Click
     Click Item    event_label
-    Sleep    2
+    Sleep    1
     Mouse Double Click
-    Sleep    2
     Verify Label    selectionIndicatorLabel    left button up
 
 Verify Incomplete Mouse Position Exception

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -3,6 +3,7 @@ from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from WhiteLibrary.utils.click import Clicks
 
+
 class ButtonKeywords(LibraryComponent):
     @keyword
     def click_button(self, locator, x_offset=0, y_offset=0):

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -1,18 +1,21 @@
 from TestStack.White.UIItems import Button, CheckBox, RadioButton
+from TestStack.White.InputDevices import Mouse
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-
+from System.Windows import Point, Rect
+from TestStack.White.UIA import RectX
+from robot.api import logger
 
 class ButtonKeywords(LibraryComponent):
     @keyword
-    def click_button(self, locator):
+    def click_button(self, locator, x_offset=0, y_offset=0):
         """Clicks a button.
 
         ``locator`` is the locator of the button.
         Locator syntax is explained in `Item locators`.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
-        button.Click()
+        self.click(button, x_offset, y_offset)
 
     @keyword
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):
@@ -122,3 +125,17 @@ class ButtonKeywords(LibraryComponent):
         """
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)
         return checkbox.IsSelected
+
+    #Low level helper function to handle offset related details.
+    def click(self, item, x_offset, y_offset):
+        item_bounds = item.Bounds
+        item_center = RectX.Center(item_bounds)
+        offset_position = Point(int(item_center.X) + int(x_offset),
+                                int(item_center.Y) + int(y_offset))
+        if not item_bounds.Contains(offset_position):
+            raise AssertionError("click location out of bounds")
+
+        logger.info("item center:" + str(item_center), True, True)
+        logger.info("item bounds:" + str(item_bounds), True, True)
+        logger.info("click location:" + str(offset_position), True, True)
+        Mouse.Instance.Click(offset_position)

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -16,7 +16,10 @@ class ButtonKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
-        Clicks.click(button, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            button.Click()
+        else:
+            Clicks.click(button, x_offset, y_offset)
 
     @keyword
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -127,5 +127,3 @@ class ButtonKeywords(LibraryComponent):
         """
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)
         return checkbox.IsSelected
-
-

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -1,7 +1,7 @@
 from TestStack.White.UIItems import Button, CheckBox, RadioButton
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
+from WhiteLibrary.utils.click import Clicks
 
 class ButtonKeywords(LibraryComponent):
     @keyword
@@ -16,7 +16,7 @@ class ButtonKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
-        UiItemKeywords.click(button, x_offset, y_offset)
+        Clicks.click(button, x_offset, y_offset)
 
     @keyword
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -9,7 +9,11 @@ class ButtonKeywords(LibraryComponent):
         """Clicks a button.
 
         ``locator`` is the locator of the button.
+
         Locator syntax is explained in `Item locators`.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
         UiItemKeywords.click(button, x_offset, y_offset)

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -1,10 +1,7 @@
 from TestStack.White.UIItems import Button, CheckBox, RadioButton
-from TestStack.White.InputDevices import Mouse
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-from System.Windows import Point, Rect
-from TestStack.White.UIA import RectX
-from robot.api import logger
+from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
 
 class ButtonKeywords(LibraryComponent):
     @keyword
@@ -15,7 +12,7 @@ class ButtonKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
-        self.click(button, x_offset, y_offset)
+        UiItemKeywords.click(button, x_offset, y_offset)
 
     @keyword
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):
@@ -126,16 +123,4 @@ class ButtonKeywords(LibraryComponent):
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)
         return checkbox.IsSelected
 
-    #Low level helper function to handle offset related details.
-    def click(self, item, x_offset, y_offset):
-        item_bounds = item.Bounds
-        item_center = RectX.Center(item_bounds)
-        offset_position = Point(int(item_center.X) + int(x_offset),
-                                int(item_center.Y) + int(y_offset))
-        if not item_bounds.Contains(offset_position):
-            raise AssertionError("click location out of bounds")
 
-        logger.info("item center:" + str(item_center), True, True)
-        logger.info("item bounds:" + str(item_bounds), True, True)
-        logger.info("click location:" + str(offset_position), True, True)
-        Mouse.Instance.Click(offset_position)

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -13,7 +13,7 @@ class ButtonKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
         UiItemKeywords.click(button, x_offset, y_offset)

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -16,10 +16,7 @@ class ButtonKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         button = self.state._get_typed_item_by_locator(Button, locator)
-        if x_offset == 0 and y_offset == 0:
-            button.Click()
-        else:
-            Clicks.click(button, x_offset, y_offset)
+        Clicks.click(button, x_offset, y_offset)
 
     @keyword
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -283,7 +283,6 @@ class ListViewKeywords(LibraryComponent):
         row = self._get_row(locator, column_name, cell_text)
         Clicks.right_click(row, x_offset, y_offset)
 
-
     @keyword
     def right_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
         """Right clicks a listview row at index.

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -1,7 +1,7 @@
 from TestStack.White.UIItems import ListView
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
+from WhiteLibrary.utils.click import Clicks
 
 class ListViewKeywords(LibraryComponent):
     @keyword
@@ -22,7 +22,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
         """
         cell = self._get_cell(locator, column_name, row_index)
-        UiItemKeywords.double_click(cell, x_offset, y_offset)
+        Clicks.double_click(cell, x_offset, y_offset)
 
     @keyword
     def double_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
@@ -42,7 +42,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        UiItemKeywords.double_click(cell, x_offset, y_offset)
+        Clicks.double_click(cell, x_offset, y_offset)
 
     @keyword
     def double_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
@@ -61,7 +61,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
         """
         row = self._get_row(locator, column_name, cell_text)
-        UiItemKeywords.double_click(row, x_offset, y_offset)
+        Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
     def double_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
@@ -79,7 +79,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row By Index | id:addressList | 4 |
         """
         row = self._get_row_by_index(locator, row_index)
-        UiItemKeywords.double_click(row, x_offset, y_offset)
+        Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
     def get_listview_cell_text(self, locator, column_name, row_index):
@@ -262,7 +262,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
-        UiItemKeywords.right_click(cell, x_offset, y_offset)
+        Clicks.right_click(cell, x_offset, y_offset)
 
     @keyword
     def right_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
@@ -271,7 +271,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        UiItemKeywords.right_click(cell, x_offset, y_offset)
+        Clicks.right_click(cell, x_offset, y_offset)
 
     @keyword
     def right_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
@@ -280,7 +280,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
-        UiItemKeywords.right_click(row, x_offset, y_offset)
+        Clicks.right_click(row, x_offset, y_offset)
 
     @keyword
     def right_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
@@ -289,7 +289,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
-        UiItemKeywords.right_click(row, x_offset, y_offset)
+        Clicks.right_click(row, x_offset, y_offset)
 
     @keyword
     def select_listview_cell(self, locator, column_name, row_index):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -1,7 +1,7 @@
 from TestStack.White.UIItems import ListView
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-
+from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
 
 class ListViewKeywords(LibraryComponent):
     @keyword
@@ -244,40 +244,40 @@ class ListViewKeywords(LibraryComponent):
                                      .format(column_name, cell_text, expected))
 
     @keyword
-    def right_click_listview_cell(self, locator, column_name, row_index):
+    def right_click_listview_cell(self, locator, column_name, row_index, x_offset=0, y_offset=0):
         """Right clicks a listview cell using its column name and row index.
 
         See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
-        cell.RightClick()
+        UiItemKeywords.right_click(cell, x_offset, y_offset)
 
     @keyword
-    def right_click_listview_cell_by_index(self, locator, row_index, column_index):
+    def right_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
         """Right clicks a listview cell at index.
 
         See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        cell.RightClick()
+        UiItemKeywords.right_click(cell, x_offset, y_offset)
 
     @keyword
-    def right_click_listview_row(self, locator, column_name, cell_text):
+    def right_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
         """Right clicks a listview row that has given text in given column.
 
         See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
-        row.RightClick()
+        UiItemKeywords.right_click(row, x_offset, y_offset)
 
     @keyword
-    def right_click_listview_row_by_index(self, locator, row_index):
+    def right_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
         """Right clicks a listview row at index.
 
         See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
-        row.RightClick()
+        UiItemKeywords.right_click(row, x_offset, y_offset)
 
     @keyword
     def select_listview_cell(self, locator, column_name, row_index):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -22,7 +22,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
         """
         cell = self._get_cell(locator, column_name, row_index)
-        Clicks.double_click(cell, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            cell.DoubleClick()
+        else:
+            Clicks.double_click(cell, x_offset, y_offset)
 
     @keyword
     def double_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
@@ -42,7 +45,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        Clicks.double_click(cell, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            cell.DoubleClick()
+        else:
+            Clicks.double_click(cell, x_offset, y_offset)
 
     @keyword
     def double_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
@@ -61,7 +67,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
         """
         row = self._get_row(locator, column_name, cell_text)
-        Clicks.double_click(row, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            row.DoubleClick()
+        else:
+            Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
     def double_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
@@ -79,7 +88,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row By Index | id:addressList | 4 |
         """
         row = self._get_row_by_index(locator, row_index)
-        Clicks.double_click(row, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            row.DoubleClick()
+        else:
+            Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
     def get_listview_cell_text(self, locator, column_name, row_index):
@@ -262,7 +274,10 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
-        Clicks.right_click(cell, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            cell.RightClick()
+        else:
+            Clicks.right_click(cell, x_offset, y_offset)
 
     @keyword
     def right_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
@@ -271,7 +286,10 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        Clicks.right_click(cell, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            cell.RightClick()
+        else:
+            Clicks.right_click(cell, x_offset, y_offset)
 
     @keyword
     def right_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
@@ -280,7 +298,11 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
-        Clicks.right_click(row, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            row.RightClick()
+        else:
+            Clicks.right_click(row, x_offset, y_offset)
+
 
     @keyword
     def right_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
@@ -289,7 +311,10 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
-        Clicks.right_click(row, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            row.RightClick()
+        else:
+            Clicks.right_click(row, x_offset, y_offset)
 
     @keyword
     def select_listview_cell(self, locator, column_name, row_index):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -5,7 +5,7 @@ from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
 
 class ListViewKeywords(LibraryComponent):
     @keyword
-    def double_click_listview_cell(self, locator, column_name, row_index):
+    def double_click_listview_cell(self, locator, column_name, row_index, x_offset=0, y_offset=0):
         """Double clicks a listview cell.
 
         ``locator`` is the locator of the listview.
@@ -19,10 +19,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
         """
         cell = self._get_cell(locator, column_name, row_index)
-        cell.DoubleClick()
+        UiItemKeywords.double_click(cell, x_offset, y_offset)
 
     @keyword
-    def double_click_listview_cell_by_index(self, locator, row_index, column_index):
+    def double_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
         """Double clicks a listview cell at index.
 
         ``locator`` is the locator of the listview.
@@ -36,10 +36,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        cell.DoubleClick()
+        UiItemKeywords.double_click(cell, x_offset, y_offset)
 
     @keyword
-    def double_click_listview_row(self, locator, column_name, cell_text):
+    def double_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
         """Double clicks a listview row.
 
         ``locator`` is the locator of the listview.
@@ -52,10 +52,10 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
         """
         row = self._get_row(locator, column_name, cell_text)
-        row.DoubleClick()
+        UiItemKeywords.double_click(row, x_offset, y_offset)
 
     @keyword
-    def double_click_listview_row_by_index(self, locator, row_index):
+    def double_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
         """Double clicks a listview row at index.
 
         ``locator`` is the locator of the listview.
@@ -67,7 +67,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row By Index | id:addressList | 4 |
         """
         row = self._get_row_by_index(locator, row_index)
-        row.DoubleClick()
+        UiItemKeywords.double_click(row, x_offset, y_offset)
 
     @keyword
     def get_listview_cell_text(self, locator, column_name, row_index):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -22,10 +22,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
         """
         cell = self._get_cell(locator, column_name, row_index)
-        if x_offset == 0 and y_offset == 0:
-            cell.DoubleClick()
-        else:
-            Clicks.double_click(cell, x_offset, y_offset)
+        Clicks.double_click(cell, x_offset, y_offset)
 
     @keyword
     def double_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
@@ -45,10 +42,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        if x_offset == 0 and y_offset == 0:
-            cell.DoubleClick()
-        else:
-            Clicks.double_click(cell, x_offset, y_offset)
+        Clicks.double_click(cell, x_offset, y_offset)
 
     @keyword
     def double_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
@@ -67,10 +61,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
         """
         row = self._get_row(locator, column_name, cell_text)
-        if x_offset == 0 and y_offset == 0:
-            row.DoubleClick()
-        else:
-            Clicks.double_click(row, x_offset, y_offset)
+        Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
     def double_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
@@ -88,10 +79,7 @@ class ListViewKeywords(LibraryComponent):
         | Double Click Listview Row By Index | id:addressList | 4 |
         """
         row = self._get_row_by_index(locator, row_index)
-        if x_offset == 0 and y_offset == 0:
-            row.DoubleClick()
-        else:
-            Clicks.double_click(row, x_offset, y_offset)
+        Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
     def get_listview_cell_text(self, locator, column_name, row_index):
@@ -274,10 +262,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Cell` for details about arguments ``locator``, ``column_name``, and ``row_index``.
         """
         cell = self._get_cell(locator, column_name, row_index)
-        if x_offset == 0 and y_offset == 0:
-            cell.RightClick()
-        else:
-            Clicks.right_click(cell, x_offset, y_offset)
+        Clicks.right_click(cell, x_offset, y_offset)
 
     @keyword
     def right_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
@@ -286,10 +271,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Cell By Index` for details about arguments ``locator``, ``row_index``, and ``column_index``.
         """
         cell = self._get_cell_by_index(locator, row_index, column_index)
-        if x_offset == 0 and y_offset == 0:
-            cell.RightClick()
-        else:
-            Clicks.right_click(cell, x_offset, y_offset)
+        Clicks.right_click(cell, x_offset, y_offset)
 
     @keyword
     def right_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
@@ -298,10 +280,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Row` for details about the arguments ``locator``, ``column_name``, and ``cell_text``.
         """
         row = self._get_row(locator, column_name, cell_text)
-        if x_offset == 0 and y_offset == 0:
-            row.RightClick()
-        else:
-            Clicks.right_click(row, x_offset, y_offset)
+        Clicks.right_click(row, x_offset, y_offset)
 
 
     @keyword
@@ -311,10 +290,7 @@ class ListViewKeywords(LibraryComponent):
         See `Double Click Listview Row By Index` for details about arguments ``locator`` and ``row_index``.
         """
         row = self._get_row_by_index(locator, row_index)
-        if x_offset == 0 and y_offset == 0:
-            row.RightClick()
-        else:
-            Clicks.right_click(row, x_offset, y_offset)
+        Clicks.right_click(row, x_offset, y_offset)
 
     @keyword
     def select_listview_cell(self, locator, column_name, row_index):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -15,6 +15,9 @@ class ListViewKeywords(LibraryComponent):
 
         ``row_index`` is the zero-based row index.
 
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
+
         Example:
         | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
         """
@@ -32,6 +35,9 @@ class ListViewKeywords(LibraryComponent):
 
         ``column_index`` is the zero-based column index.
 
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
+
         Example:
         | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
         """
@@ -48,6 +54,9 @@ class ListViewKeywords(LibraryComponent):
         ``column_name`` and ``cell_text`` define the row. Row is the first matching row where text in column
         ``column_name`` is ``cell_text``.
 
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
+
         Example:
         | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
         """
@@ -62,6 +71,9 @@ class ListViewKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
 
         ``row_index`` is the zero-based row index.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
 
         Example:
         | Double Click Listview Row By Index | id:addressList | 4 |

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -3,6 +3,7 @@ from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from WhiteLibrary.utils.click import Clicks
 
+
 class ListViewKeywords(LibraryComponent):
     @keyword
     def double_click_listview_cell(self, locator, column_name, row_index, x_offset=0, y_offset=0):

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -16,7 +16,7 @@ class ListViewKeywords(LibraryComponent):
         ``row_index`` is the zero-based row index.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
 
         Example:
         | Double Click Listview Cell | id:addressList | Street | 0 | # double click cell in the column "Street" of the first row |
@@ -36,7 +36,7 @@ class ListViewKeywords(LibraryComponent):
         ``column_index`` is the zero-based column index.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
 
         Example:
         | Double Click Listview Cell By Index | id:addressList | 0 | 0 |
@@ -55,7 +55,7 @@ class ListViewKeywords(LibraryComponent):
         ``column_name`` is ``cell_text``.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
 
         Example:
         | Double Click Listview Row | id:addressList | City | Helsinki | # double click row that has the text "Helsinki" in the column "City" |
@@ -73,7 +73,7 @@ class ListViewKeywords(LibraryComponent):
         ``row_index`` is the zero-based row index.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
 
         Example:
         | Double Click Listview Row By Index | id:addressList | 4 |

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -1,7 +1,7 @@
 from TestStack.White.UIItems.MenuItems import Menu
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
+from WhiteLibrary.utils.click import Clicks
 
 class MenuKeywords(LibraryComponent):
     @keyword
@@ -27,7 +27,7 @@ class MenuKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         menu_button = self.state._get_typed_item_by_locator(Menu, locator)
-        UiItemKeywords.click(menu_button, x_offset, y_offset)
+        Clicks.click(menu_button, x_offset, y_offset)
 
     @keyword
     def click_item_in_popup_menu(self, *text_path):

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -24,7 +24,7 @@ class MenuKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
         """
         menu_button = self.state._get_typed_item_by_locator(Menu, locator)
         UiItemKeywords.click(menu_button, x_offset, y_offset)

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -28,10 +28,7 @@ class MenuKeywords(LibraryComponent):
         """
 
         menu_button = self.state._get_typed_item_by_locator(Menu, locator)
-        if x_offset == 0 and y_offset == 0:
-            menu_button.Click()
-        else:
-            Clicks.click(menu_button, x_offset, y_offset)
+        Clicks.click(menu_button, x_offset, y_offset)
 
     @keyword
     def click_item_in_popup_menu(self, *text_path):

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -1,7 +1,7 @@
 from TestStack.White.UIItems.MenuItems import Menu
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-
+from WhiteLibrary.keywords.items.uiitem import UiItemKeywords
 
 class MenuKeywords(LibraryComponent):
     @keyword
@@ -17,14 +17,14 @@ class MenuKeywords(LibraryComponent):
         self.state._verify_value(expected, menu.Name)
 
     @keyword
-    def click_menu_button(self, locator):
+    def click_menu_button(self, locator, x_offset, y_offset):
         """Clicks a menu button.
 
         ``locator`` is the locator of the menu button.
         Locator syntax is explained in `Item locators`.
         """
         menu_button = self.state._get_typed_item_by_locator(Menu, locator)
-        menu_button.Click()
+        UiItemKeywords.click(menu_button, x_offset, y_offset)
 
     @keyword
     def click_item_in_popup_menu(self, *text_path):

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -26,8 +26,12 @@ class MenuKeywords(LibraryComponent):
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
         mouse position relative to the center of the item.
         """
+
         menu_button = self.state._get_typed_item_by_locator(Menu, locator)
-        Clicks.click(menu_button, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            menu_button.Click()
+        else:
+            Clicks.click(menu_button, x_offset, y_offset)
 
     @keyword
     def click_item_in_popup_menu(self, *text_path):

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -3,6 +3,7 @@ from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from WhiteLibrary.utils.click import Clicks
 
+
 class MenuKeywords(LibraryComponent):
     @keyword
     def verify_menu(self, locator, expected):

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -17,11 +17,14 @@ class MenuKeywords(LibraryComponent):
         self.state._verify_value(expected, menu.Name)
 
     @keyword
-    def click_menu_button(self, locator, x_offset, y_offset):
+    def click_menu_button(self, locator, x_offset=0, y_offset=0):
         """Clicks a menu button.
 
         ``locator`` is the locator of the menu button.
         Locator syntax is explained in `Item locators`.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
         """
         menu_button = self.state._get_typed_item_by_locator(Menu, locator)
         UiItemKeywords.click(menu_button, x_offset, y_offset)

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -2,9 +2,8 @@ from TestStack.White.UIItems import UIItem   # noqa: F401
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from WhiteLibrary.utils.click import Clicks
-
-from TestStack.White.InputDevices import Mouse
 from robot.api import logger
+
 
 class UiItemKeywords(LibraryComponent):
     @keyword

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -18,10 +18,7 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        if x_offset == 0 and y_offset == 0:
-            item.Click()
-        else:
-            Clicks.click(item, x_offset, y_offset)
+        Clicks.click(item, x_offset, y_offset)
 
 
     @keyword
@@ -35,10 +32,7 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        if x_offset == 0 and y_offset == 0:
-            item.RightClick()
-        else:
-            Clicks.right_click(item, x_offset, y_offset)
+        Clicks.right_click(item, x_offset, y_offset)
 
 
     @keyword
@@ -52,10 +46,7 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        if x_offset == 0 and y_offset == 0:
-            item.DoubleClick()
-        else:
-            Clicks.double_click(item, x_offset, y_offset)
+        Clicks.double_click(item, x_offset, y_offset)
 
 
     @keyword

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -18,7 +18,11 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        Clicks.click(item, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            item.Click()
+        else:
+            Clicks.click(item, x_offset, y_offset)
+
 
     @keyword
     def right_click_item(self, locator, x_offset=0, y_offset=0):
@@ -31,7 +35,11 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        Clicks.right_click(item, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            item.RightClick()
+        else:
+            Clicks.right_click(item, x_offset, y_offset)
+
 
     @keyword
     def double_click_item(self, locator, x_offset=0, y_offset=0):
@@ -44,7 +52,11 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        Clicks.double_click(item, x_offset, y_offset)
+        if x_offset == 0 and y_offset == 0:
+            item.DoubleClick()
+        else:
+            Clicks.double_click(item, x_offset, y_offset)
+
 
     @keyword
     def get_items(self, locator):

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -15,7 +15,7 @@ class UiItemKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
         UiItemKeywords.click(item, x_offset, y_offset)
@@ -28,7 +28,7 @@ class UiItemKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
         UiItemKeywords.right_click(item, x_offset, y_offset)
@@ -41,7 +41,7 @@ class UiItemKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
-        mouse position relative to the center of the item. Their default is 0.
+        mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
         UiItemKeywords.double_click(item, x_offset, y_offset)

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -1,28 +1,31 @@
 from TestStack.White.UIItems import UIItem   # noqa: F401
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-
+from TestStack.White.UIA import RectX
+from System.Windows import Point, Rect
+from TestStack.White.InputDevices import Mouse
+from robot.api import logger
 
 class UiItemKeywords(LibraryComponent):
     @keyword
-    def click_item(self, locator):
+    def click_item(self, locator, x_offset=0, y_offset=0):
         """Clicks an item.
 
         ``locator`` is the locator of the item.
         Locator syntax is explained in `Item locators`.
         """
         item = self.state._get_item_by_locator(locator)
-        item.Click()
+        UiItemKeywords.click(item, x_offset, y_offset)
 
     @keyword
-    def right_click_item(self, locator):
+    def right_click_item(self, locator, x_offset=0, y_offset=0):
         """Right clicks an item.
 
         ``locator`` is the locator of the item.
         Locator syntax is explained in `Item locators`.
         """
         item = self.state._get_item_by_locator(locator)
-        item.RightClick()
+        UiItemKeywords.right_click(item, x_offset, y_offset)
 
     @keyword
     def double_click_item(self, locator):
@@ -50,3 +53,27 @@ class UiItemKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
         """
         return self.state._get_item_by_locator(locator)
+
+    #Low level function to handle offset click.
+    @staticmethod
+    def click(item, x_offset=0, y_offset=0):
+        offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
+        Mouse.Instance.Click(offset_position)
+
+    #Low level helper function to handle offset right click.
+    @staticmethod
+    def right_click(item, x_offset=0, y_offset=0):
+        offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
+        Mouse.Instance.Location = offset_position
+        Mouse.Instance.RightClick()
+
+    #Helper function to translate item center to offset point
+    @staticmethod
+    def _get_offset_point(item, x_offset, y_offset):
+        item_bounds = item.Bounds
+        item_center = RectX.Center(item_bounds)
+        offset_point = Point(int(item_center.X) + int(x_offset),
+                                int(item_center.Y) + int(y_offset))
+        if not item_bounds.Contains(offset_point):
+            raise AssertionError("click location out of bounds")
+        return offset_point

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -1,8 +1,8 @@
 from TestStack.White.UIItems import UIItem   # noqa: F401
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
-from TestStack.White.UIA import RectX
-from System.Windows import Point, Rect
+from WhiteLibrary.utils.click import Clicks
+
 from TestStack.White.InputDevices import Mouse
 from robot.api import logger
 
@@ -18,7 +18,7 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        UiItemKeywords.click(item, x_offset, y_offset)
+        Clicks.click(item, x_offset, y_offset)
 
     @keyword
     def right_click_item(self, locator, x_offset=0, y_offset=0):
@@ -31,7 +31,7 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        UiItemKeywords.right_click(item, x_offset, y_offset)
+        Clicks.right_click(item, x_offset, y_offset)
 
     @keyword
     def double_click_item(self, locator, x_offset=0, y_offset=0):
@@ -44,7 +44,7 @@ class UiItemKeywords(LibraryComponent):
         mouse position relative to the center of the item.
         """
         item = self.state._get_item_by_locator(locator)
-        UiItemKeywords.double_click(item, x_offset, y_offset)
+        Clicks.double_click(item, x_offset, y_offset)
 
     @keyword
     def get_items(self, locator):
@@ -63,32 +63,3 @@ class UiItemKeywords(LibraryComponent):
         """
         return self.state._get_item_by_locator(locator)
 
-    #Low level function to handle offset click.
-    @staticmethod
-    def click(item, x_offset=0, y_offset=0):
-        offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
-        Mouse.Instance.Click(offset_position)
-
-    #Low level helper function to handle offset right click.
-    @staticmethod
-    def right_click(item, x_offset=0, y_offset=0):
-        offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
-        Mouse.Instance.Location = offset_position
-        Mouse.Instance.RightClick()
-
-    #Low level helper function to handle offset right click.
-    @staticmethod
-    def double_click(item, x_offset=0, y_offset=0):
-        offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
-        Mouse.Instance.DoubleClick(offset_position)
-
-    #Helper function to translate item center to offset point
-    @staticmethod
-    def _get_offset_point(item, x_offset, y_offset):
-        item_bounds = item.Bounds
-        item_center = RectX.Center(item_bounds)
-        offset_point = Point(int(item_center.X) + int(x_offset),
-                                int(item_center.Y) + int(y_offset))
-        if not item_bounds.Contains(offset_point):
-            raise AssertionError("click location out of bounds")
-        return offset_point

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -2,7 +2,6 @@ from TestStack.White.UIItems import UIItem   # noqa: F401
 from WhiteLibrary.keywords.librarycomponent import LibraryComponent
 from WhiteLibrary.keywords.robotlibcore import keyword
 from WhiteLibrary.utils.click import Clicks
-from robot.api import logger
 
 
 class UiItemKeywords(LibraryComponent):
@@ -19,7 +18,6 @@ class UiItemKeywords(LibraryComponent):
         item = self.state._get_item_by_locator(locator)
         Clicks.click(item, x_offset, y_offset)
 
-
     @keyword
     def right_click_item(self, locator, x_offset=0, y_offset=0):
         """Right clicks an item.
@@ -33,7 +31,6 @@ class UiItemKeywords(LibraryComponent):
         item = self.state._get_item_by_locator(locator)
         Clicks.right_click(item, x_offset, y_offset)
 
-
     @keyword
     def double_click_item(self, locator, x_offset=0, y_offset=0):
         """Double clicks an item.
@@ -46,7 +43,6 @@ class UiItemKeywords(LibraryComponent):
         """
         item = self.state._get_item_by_locator(locator)
         Clicks.double_click(item, x_offset, y_offset)
-
 
     @keyword
     def get_items(self, locator):
@@ -64,4 +60,3 @@ class UiItemKeywords(LibraryComponent):
         Locator syntax is explained in `Item locators`.
         """
         return self.state._get_item_by_locator(locator)
-

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -13,6 +13,9 @@ class UiItemKeywords(LibraryComponent):
 
         ``locator`` is the locator of the item.
         Locator syntax is explained in `Item locators`.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
         """
         item = self.state._get_item_by_locator(locator)
         UiItemKeywords.click(item, x_offset, y_offset)
@@ -23,6 +26,9 @@ class UiItemKeywords(LibraryComponent):
 
         ``locator`` is the locator of the item.
         Locator syntax is explained in `Item locators`.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
         """
         item = self.state._get_item_by_locator(locator)
         UiItemKeywords.right_click(item, x_offset, y_offset)
@@ -33,6 +39,9 @@ class UiItemKeywords(LibraryComponent):
 
         ``locator`` is the locator of the item.
         Locator syntax is explained in `Item locators`.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
+        mouse position relative to the center of the item. Their default is 0.
         """
         item = self.state._get_item_by_locator(locator)
         UiItemKeywords.double_click(item, x_offset, y_offset)

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -28,14 +28,14 @@ class UiItemKeywords(LibraryComponent):
         UiItemKeywords.right_click(item, x_offset, y_offset)
 
     @keyword
-    def double_click_item(self, locator):
+    def double_click_item(self, locator, x_offset=0, y_offset=0):
         """Double clicks an item.
 
         ``locator`` is the locator of the item.
         Locator syntax is explained in `Item locators`.
         """
         item = self.state._get_item_by_locator(locator)
-        item.DoubleClick()
+        UiItemKeywords.double_click(item, x_offset, y_offset)
 
     @keyword
     def get_items(self, locator):
@@ -66,6 +66,12 @@ class UiItemKeywords(LibraryComponent):
         offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
         Mouse.Instance.Location = offset_position
         Mouse.Instance.RightClick()
+
+    #Low level helper function to handle offset right click.
+    @staticmethod
+    def double_click(item, x_offset=0, y_offset=0):
+        offset_position = UiItemKeywords._get_offset_point(item, x_offset, y_offset)
+        Mouse.Instance.DoubleClick(offset_position)
 
     #Helper function to translate item center to offset point
     @staticmethod

--- a/src/WhiteLibrary/utils/click.py
+++ b/src/WhiteLibrary/utils/click.py
@@ -2,8 +2,9 @@ from System.Windows import Point
 from TestStack.White.UIA import RectX
 from TestStack.White.InputDevices import Mouse
 
+
 class Clicks():
-    #Low level function to handle offset click.
+    # Low level function to handle offset click.
     @staticmethod
     def click(item, x_offset, y_offset):
         if x_offset == 0 and y_offset == 0:
@@ -12,7 +13,7 @@ class Clicks():
             offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
             Mouse.Instance.Click(offset_position)
 
-    #Low level helper function to handle offset right click.
+    # Low level helper function to handle offset right click.
     @staticmethod
     def right_click(item, x_offset, y_offset):
         if x_offset == 0 and y_offset == 0:
@@ -22,7 +23,7 @@ class Clicks():
             Mouse.Instance.Location = offset_position
             Mouse.Instance.RightClick()
 
-    #Low level helper function to handle offset double click.
+    # Low level helper function to handle offset double click.
     @staticmethod
     def double_click(item, x_offset, y_offset):
         if x_offset == 0 and y_offset == 0:
@@ -31,13 +32,13 @@ class Clicks():
             offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
             Mouse.Instance.DoubleClick(offset_position)
 
-    #Helper function to translate item center to offset point
+    # Helper function to translate item center to offset point
     @staticmethod
     def _get_offset_point(item, x_offset, y_offset):
         item_bounds = item.Bounds
         item_center = RectX.Center(item_bounds)
         offset_point = Point(int(item_center.X) + int(x_offset),
-                                int(item_center.Y) + int(y_offset))
+                             int(item_center.Y) + int(y_offset))
         if not item_bounds.Contains(offset_point):
             raise AssertionError("click location out of bounds")
         return offset_point

--- a/src/WhiteLibrary/utils/click.py
+++ b/src/WhiteLibrary/utils/click.py
@@ -1,4 +1,4 @@
-from System.Windows import Point, Rect
+from System.Windows import Point
 from TestStack.White.UIA import RectX
 from TestStack.White.InputDevices import Mouse
 

--- a/src/WhiteLibrary/utils/click.py
+++ b/src/WhiteLibrary/utils/click.py
@@ -1,0 +1,34 @@
+from System.Windows import Point, Rect
+from TestStack.White.UIA import RectX
+from TestStack.White.InputDevices import Mouse
+
+class Clicks():
+    #Low level function to handle offset click.
+    @staticmethod
+    def click(item, x_offset, y_offset):
+        offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
+        Mouse.Instance.Click(offset_position)
+
+    #Low level helper function to handle offset right click.
+    @staticmethod
+    def right_click(item, x_offset, y_offset):
+        offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
+        Mouse.Instance.Location = offset_position
+        Mouse.Instance.RightClick()
+
+    #Low level helper function to handle offset double click.
+    @staticmethod
+    def double_click(item, x_offset, y_offset):
+        offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
+        Mouse.Instance.DoubleClick(offset_position)
+
+    #Helper function to translate item center to offset point
+    @staticmethod
+    def _get_offset_point(item, x_offset, y_offset):
+        item_bounds = item.Bounds
+        item_center = RectX.Center(item_bounds)
+        offset_point = Point(int(item_center.X) + int(x_offset),
+                                int(item_center.Y) + int(y_offset))
+        if not item_bounds.Contains(offset_point):
+            raise AssertionError("click location out of bounds")
+        return offset_point

--- a/src/WhiteLibrary/utils/click.py
+++ b/src/WhiteLibrary/utils/click.py
@@ -6,21 +6,30 @@ class Clicks():
     #Low level function to handle offset click.
     @staticmethod
     def click(item, x_offset, y_offset):
-        offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
-        Mouse.Instance.Click(offset_position)
+        if x_offset == 0 and y_offset == 0:
+            item.Click()
+        else:
+            offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
+            Mouse.Instance.Click(offset_position)
 
     #Low level helper function to handle offset right click.
     @staticmethod
     def right_click(item, x_offset, y_offset):
-        offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
-        Mouse.Instance.Location = offset_position
-        Mouse.Instance.RightClick()
+        if x_offset == 0 and y_offset == 0:
+            item.RightClick()
+        else:
+            offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
+            Mouse.Instance.Location = offset_position
+            Mouse.Instance.RightClick()
 
     #Low level helper function to handle offset double click.
     @staticmethod
     def double_click(item, x_offset, y_offset):
-        offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
-        Mouse.Instance.DoubleClick(offset_position)
+        if x_offset == 0 and y_offset == 0:
+            item.DoubleClick()
+        else:
+            offset_position = Clicks._get_offset_point(item, x_offset, y_offset)
+            Mouse.Instance.DoubleClick(offset_position)
 
     #Helper function to translate item center to offset point
     @staticmethod


### PR DESCRIPTION
Added x,y offset optional arguments for following click keywords:
	click_button
	double_click_listview_cell
	double_click_listview_cell_by_index
	double_click_listview_row
	double_click_listview_row_by_index
	right_click_listview_cell
	right_click_listview_cell_by_index
	right_click_listview_row
	right_click_listview_row_by_index
	click_menu_button
        click_item
	right_click_item
	double_click_item

These keywords do not yet have offset arguments as they use variable length argument list 
	click_item_in_popup_menu 
	double_click_tree_node 
	right_click_tree_node
	