### PR TITLE
Item element for keywords

### DIFF
--- a/atests/feature_tests/items.robot
+++ b/atests/feature_tests/items.robot
@@ -90,6 +90,14 @@ Verify Radio Buttons
     Select Radio Button    rb_ismo
     Verify Radio Button    rb_ismo    ${TRUE}
 
+Verify Radio Buttons By Item Reference
+    ${item}=    Get Item    rb_peke
+    Select Radio Button    ${item}
+    Verify Radio Button    rb_peke    ${TRUE}
+    ${item}=    Get Item    rb_ismo
+    Select Radio Button    ${item}
+    Verify Radio Button    rb_ismo    ${TRUE}
+
 Verify Get Radio Button State
     ${old_button_state}=    Get Radio Button State    rb_ismo
     Select Radio Button     rb_ismo
@@ -163,6 +171,16 @@ Right Click An Item
 Double Click An Item
     Double Click Item    eventIndicatorLabel
     Verify Label    eventIndicatorLabel    Double-clicked 1 times
+
+Double Click An Item With Item Reference
+    ${item}=    Get Item    eventIndicatorLabel
+    Double Click Item    ${item}
+    Verify Label    eventIndicatorLabel    Double-clicked 2 times
+
+Click An Item With Incorrect Item Reference
+    ${item}=    Get Item    eventIndicatorLabel
+    ${status}    ${error_msg}    Run Keyword And Ignore Error    Click Button    ${item}
+    Should Contain    ${error_msg}    Assumed that locator item is of type item_type
 
 Click Button By Pressing Special Keys
     Input Text To Textbox    txtA    1

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -89,14 +89,14 @@ class WhiteLibrary(DynamicCore):
     since the old syntax may be *deprecated* in the future.
 
     === Item reference as a locator ===
-    Some times you may like to save your item to a variable and refer to the item using that variable. It is indeed possible, however there
-    are some details that need to be taken into account. You can use item reference to an item that is not in currently attached window or even
-    in currently attached application. The item reference completes the action in the other window but this does not attach that window. Thus
-    after referring to an item in another window you can normally continue using the attached window.
+    It is also possible to refer items with object reference. That is, you can save your item to a variable and refer to the item using that variable.
+    The need to do this can raise for instance when you search multiple items using a generic locator and pick one of the items for further action.
+    Item reference can complete the action in any window i.e. window the item is located does not need to be attached. However, this does not change
+    the attached window and the operation continues in the attached window after action on the referred item is complete.
 
     Example using item reference:
-    | ${item}= | `Get Item`         | myButton |
-    | `Click Button` | ${item}      | # clicks button by item reference |
+    | @{my_buttons}= | `Get Items`         | class_name: button |
+    | `Click Button` | ${my_buttons[2]}    | # clicks button by item reference |
 
     = Workflow example =
     | ***** Variables *****   | | | |
@@ -144,18 +144,15 @@ class WhiteLibrary(DynamicCore):
         DynamicCore.__init__(self, self.libraries)
 
     def _get_typed_item_by_locator(self, item_type, locator):
-        # Test if locator is already an UIItem
         if isinstance(locator, UIItem):
-            if isinstance(locator, item_type):
-                return locator
-            else:
+            if not isinstance(locator, item_type):
                 raise TypeError('Assumed that locator item is of type item_type')
+            return locator
         else:
             search_criteria = self._get_search_criteria(locator)
             return self.window.Get[item_type](search_criteria)
 
     def _get_item_by_locator(self, locator):
-        # Test if locator is already an UIItem
         if isinstance(locator, UIItem):
             return locator
         else:

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -7,7 +7,7 @@ clr.AddReference('System')
 clr.AddReference(DLL_PATH)
 from System.Windows.Automation import AutomationElement, ControlType    # noqa: E402
 from TestStack.White.UIItems.Finders import SearchCriteria    # noqa: E402
-from TestStack.White.UIItems import UIItem
+from TestStack.White.UIItems import UIItem    # noqa: E402
 from WhiteLibrary.keywords import ApplicationKeywords, KeyboardKeywords, WindowKeywords, ScreenshotKeywords, WhiteConfigurationKeywords    # noqa: E402
 from WhiteLibrary.keywords.items import (ButtonKeywords,
                                          LabelKeywords,
@@ -141,7 +141,7 @@ class WhiteLibrary(DynamicCore):
         DynamicCore.__init__(self, self.libraries)
 
     def _get_typed_item_by_locator(self, item_type, locator):
-        #Test if locator is already an UIItem
+        # Test if locator is already an UIItem
         if isinstance(locator, UIItem):
             if isinstance(locator, item_type):
                 return locator
@@ -152,7 +152,7 @@ class WhiteLibrary(DynamicCore):
             return self.window.Get[item_type](search_criteria)
 
     def _get_item_by_locator(self, locator):
-        #Test if locator is already an UIItem
+        # Test if locator is already an UIItem
         if isinstance(locator, UIItem):
             return locator
         else:

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -66,8 +66,6 @@ class WhiteLibrary(DynamicCore):
     == Item locators ==
     Keywords that access UI items (e.g. `Click Button`) use a ``locator`` argument.
     The locator consists of a locator prefix that specifies the search criteria, and the locator value.
-    In most cases alongside locators you can use item reference. That is you can first save your item in a variable and then use that
-    item in place of a locator.
 
     Locator syntax is ``prefix:value``.
     The following locator prefixes are available:
@@ -87,13 +85,18 @@ class WhiteLibrary(DynamicCore):
     | `Click Button` | text:Click here! | # clicks button by the button text  |
     | `Click Button` | index:2          | # clicks button whose index is 2    |
 
-    Example using item reference:
-
-    | ${item}= | `Get Item`         | myButton |
-    | `Click Button` | ${item}      | # clicks button by item reference |
-
     *Note:* Old locator syntax ``prefix=value`` is also valid but it is recommended to use the ``prefix:value`` syntax
     since the old syntax may be *deprecated* in the future.
+
+    === Item reference as a locator ===
+    Some times you may like to save your item to a variable and refer to the item using that variable. It is indeed possible, however there
+    are some details that need to be taken into account. You can use item reference to an item that is not in currently attached window or even
+    in currently attached application. The item reference completes the action in the other window but this does not attach that window. Thus
+    after referring to an item in another window you can normally continue using the attached window.
+
+    Example using item reference:
+    | ${item}= | `Get Item`         | myButton |
+    | `Click Button` | ${item}      | # clicks button by item reference |
 
     = Workflow example =
     | ***** Variables *****   | | | |

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -66,6 +66,8 @@ class WhiteLibrary(DynamicCore):
     == Item locators ==
     Keywords that access UI items (e.g. `Click Button`) use a ``locator`` argument.
     The locator consists of a locator prefix that specifies the search criteria, and the locator value.
+    In most cases alongside locators you can use item reference. That is you can first save your item in a variable and then use that
+    item in place of a locator.
 
     Locator syntax is ``prefix:value``.
     The following locator prefixes are available:
@@ -84,6 +86,11 @@ class WhiteLibrary(DynamicCore):
     | `Click Button` | id:myButton      | # clicks button by its AutomationID |
     | `Click Button` | text:Click here! | # clicks button by the button text  |
     | `Click Button` | index:2          | # clicks button whose index is 2    |
+
+    Example using item reference:
+
+    | ${item}= | `Get Item`         | myButton |
+    | `Click Button` | ${item}      | # clicks button by item reference |
 
     *Note:* Old locator syntax ``prefix=value`` is also valid but it is recommended to use the ``prefix:value`` syntax
     since the old syntax may be *deprecated* in the future.

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -7,6 +7,7 @@ clr.AddReference('System')
 clr.AddReference(DLL_PATH)
 from System.Windows.Automation import AutomationElement, ControlType    # noqa: E402
 from TestStack.White.UIItems.Finders import SearchCriteria    # noqa: E402
+from TestStack.White.UIItems import UIItem
 from WhiteLibrary.keywords import ApplicationKeywords, KeyboardKeywords, WindowKeywords, ScreenshotKeywords, WhiteConfigurationKeywords    # noqa: E402
 from WhiteLibrary.keywords.items import (ButtonKeywords,
                                          LabelKeywords,
@@ -133,12 +134,23 @@ class WhiteLibrary(DynamicCore):
         DynamicCore.__init__(self, self.libraries)
 
     def _get_typed_item_by_locator(self, item_type, locator):
-        search_criteria = self._get_search_criteria(locator)
-        return self.window.Get[item_type](search_criteria)
+        #Test if locator is already an UIItem
+        if isinstance(locator, UIItem):
+            if isinstance(locator, item_type):
+                return locator
+            else:
+                raise TypeError('Assumed that locator item is of type item_type')
+        else:
+            search_criteria = self._get_search_criteria(locator)
+            return self.window.Get[item_type](search_criteria)
 
     def _get_item_by_locator(self, locator):
-        search_criteria = self._get_search_criteria(locator)
-        return self.window.Get(search_criteria)
+        #Test if locator is already an UIItem
+        if isinstance(locator, UIItem):
+            return locator
+        else:
+            search_criteria = self._get_search_criteria(locator)
+            return self.window.Get(search_criteria)
 
     def _get_multiple_items_by_locator(self, locator):
         search_criteria = self._get_search_criteria(locator)

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -148,16 +148,14 @@ class WhiteLibrary(DynamicCore):
             if not isinstance(locator, item_type):
                 raise TypeError('Assumed that locator item is of type item_type')
             return locator
-        else:
-            search_criteria = self._get_search_criteria(locator)
-            return self.window.Get[item_type](search_criteria)
+        search_criteria = self._get_search_criteria(locator)
+        return self.window.Get[item_type](search_criteria)
 
     def _get_item_by_locator(self, locator):
         if isinstance(locator, UIItem):
             return locator
-        else:
-            search_criteria = self._get_search_criteria(locator)
-            return self.window.Get(search_criteria)
+        search_criteria = self._get_search_criteria(locator)
+        return self.window.Get(search_criteria)
 
     def _get_multiple_items_by_locator(self, locator):
         search_criteria = self._get_search_criteria(locator)

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -9,7 +9,7 @@ class ButtonKeywords(LibraryComponent):
     def click_button(self, locator, x_offset=0, y_offset=0):
         """Clicks a button.
 
-        ``locator`` is the locator of the button or item with type Button.
+        ``locator`` is the locator of the button or Button item object.
 
         Locator syntax is explained in `Item locators`.
 
@@ -23,7 +23,7 @@ class ButtonKeywords(LibraryComponent):
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):
         """Verifies exact text in a button.
 
-        ``locator`` is the locator of the button or item with type Button.
+        ``locator`` is the locator of the button or Button item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected_text`` is the expected button text.
@@ -37,7 +37,7 @@ class ButtonKeywords(LibraryComponent):
     def button_text_should_contain(self, locator, expected_text, case_sensitive=True):
         """Verifies expected text is found in a button.
 
-        ``locator`` is the locator of the button or item with type Button.
+        ``locator`` is the locator of the button or Button item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected_text`` is the expected button text.
@@ -53,7 +53,7 @@ class ButtonKeywords(LibraryComponent):
 
         Verifies text in a button.
 
-        ``locator`` is the locator of the button or item with type Button.
+        ``locator`` is the locator of the button or Button item object.
 
         ``expected`` is the expected button text.
         """
@@ -64,7 +64,7 @@ class ButtonKeywords(LibraryComponent):
     def select_radio_button(self, locator):
         """Selects a radio button.
 
-        ``locator`` is the locator of the radio button or item with type RadioButton.
+        ``locator`` is the locator of the radio button or RadioButton item object.
         Locator syntax is explained in `Item locators`.
         """
         radiobutton = self.state._get_typed_item_by_locator(RadioButton, locator)
@@ -74,7 +74,7 @@ class ButtonKeywords(LibraryComponent):
     def verify_radio_button(self, locator, expected):
         """Verifies state of a radio button.
 
-        ``locator`` is the locator of the radio button or item with type RadioButton.
+        ``locator`` is the locator of the radio button or RadioButton item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected state (True/False).
@@ -88,7 +88,7 @@ class ButtonKeywords(LibraryComponent):
 
         Returns `True` if the radio button is selected, `False` if not.
 
-        ``locator`` is the locator of the radio button or item with type RadioButton.
+        ``locator`` is the locator of the radio button or RadioButton item object.
         Locator syntax is explained in `Item locators`.
         """
         radiobutton = self.state._get_typed_item_by_locator(RadioButton, locator)
@@ -98,7 +98,7 @@ class ButtonKeywords(LibraryComponent):
     def toggle_check_box(self, locator):
         """Toggles a check box.
 
-        ``locator`` is the locator of the check box or item with type CheckBox.
+        ``locator`` is the locator of the check box or CheckBox item object.
         Locator syntax is explained in `Item locators`.
         """
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)
@@ -108,7 +108,7 @@ class ButtonKeywords(LibraryComponent):
     def verify_check_box(self, locator, expected):
         """Verifies state of a check box.
 
-        ``locator`` is the locator of the check box or item with type CheckBox.
+        ``locator`` is the locator of the check box or CheckBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected state (True/False).
@@ -122,7 +122,7 @@ class ButtonKeywords(LibraryComponent):
 
         Returns `True` if the check box is selected, `False` if not.
 
-        ``locator`` is the locator of the check box or item with type CheckBox.
+        ``locator`` is the locator of the check box or CheckBox item object.
         Locator syntax is explained in `Item locators`.
         """
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)

--- a/src/WhiteLibrary/keywords/items/buttons.py
+++ b/src/WhiteLibrary/keywords/items/buttons.py
@@ -9,7 +9,7 @@ class ButtonKeywords(LibraryComponent):
     def click_button(self, locator, x_offset=0, y_offset=0):
         """Clicks a button.
 
-        ``locator`` is the locator of the button.
+        ``locator`` is the locator of the button or item with type Button.
 
         Locator syntax is explained in `Item locators`.
 
@@ -23,7 +23,7 @@ class ButtonKeywords(LibraryComponent):
     def button_text_should_be(self, locator, expected_text, case_sensitive=True):
         """Verifies exact text in a button.
 
-        ``locator`` is the locator of the button.
+        ``locator`` is the locator of the button or item with type Button.
         Locator syntax is explained in `Item locators`.
 
         ``expected_text`` is the expected button text.
@@ -37,7 +37,7 @@ class ButtonKeywords(LibraryComponent):
     def button_text_should_contain(self, locator, expected_text, case_sensitive=True):
         """Verifies expected text is found in a button.
 
-        ``locator`` is the locator of the button.
+        ``locator`` is the locator of the button or item with type Button.
         Locator syntax is explained in `Item locators`.
 
         ``expected_text`` is the expected button text.
@@ -53,7 +53,7 @@ class ButtonKeywords(LibraryComponent):
 
         Verifies text in a button.
 
-        ``locator`` is the locator of the button.
+        ``locator`` is the locator of the button or item with type Button.
 
         ``expected`` is the expected button text.
         """
@@ -64,7 +64,7 @@ class ButtonKeywords(LibraryComponent):
     def select_radio_button(self, locator):
         """Selects a radio button.
 
-        ``locator`` is the locator of the radio button.
+        ``locator`` is the locator of the radio button or item with type RadioButton.
         Locator syntax is explained in `Item locators`.
         """
         radiobutton = self.state._get_typed_item_by_locator(RadioButton, locator)
@@ -74,7 +74,7 @@ class ButtonKeywords(LibraryComponent):
     def verify_radio_button(self, locator, expected):
         """Verifies state of a radio button.
 
-        ``locator`` is the locator of the radio button.
+        ``locator`` is the locator of the radio button or item with type RadioButton.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected state (True/False).
@@ -88,7 +88,7 @@ class ButtonKeywords(LibraryComponent):
 
         Returns `True` if the radio button is selected, `False` if not.
 
-        ``locator`` is the locator of the radio button.
+        ``locator`` is the locator of the radio button or item with type RadioButton.
         Locator syntax is explained in `Item locators`.
         """
         radiobutton = self.state._get_typed_item_by_locator(RadioButton, locator)
@@ -98,7 +98,7 @@ class ButtonKeywords(LibraryComponent):
     def toggle_check_box(self, locator):
         """Toggles a check box.
 
-        ``locator`` is the locator of the check box.
+        ``locator`` is the locator of the check box or item with type CheckBox.
         Locator syntax is explained in `Item locators`.
         """
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)
@@ -108,7 +108,7 @@ class ButtonKeywords(LibraryComponent):
     def verify_check_box(self, locator, expected):
         """Verifies state of a check box.
 
-        ``locator`` is the locator of the check box.
+        ``locator`` is the locator of the check box or item with type CheckBox.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected state (True/False).
@@ -122,7 +122,7 @@ class ButtonKeywords(LibraryComponent):
 
         Returns `True` if the check box is selected, `False` if not.
 
-        ``locator`` is the locator of the check box.
+        ``locator`` is the locator of the check box or item with type CheckBox.
         Locator syntax is explained in `Item locators`.
         """
         checkbox = self.state._get_typed_item_by_locator(CheckBox, locator)

--- a/src/WhiteLibrary/keywords/items/label.py
+++ b/src/WhiteLibrary/keywords/items/label.py
@@ -8,7 +8,7 @@ class LabelKeywords(LibraryComponent):
     def verify_label(self, locator, expected):
         """Verifies text of a label.
 
-        ``locator`` is the locator of the label.
+        ``locator`` is the locator of the label or item with type Label.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected text.
@@ -20,7 +20,7 @@ class LabelKeywords(LibraryComponent):
     def get_text_from_label(self, locator):
         """Returns the text of a label.
 
-        ``locator`` is the locator of the label.
+        ``locator`` is the locator of the label or item with type Label.
         Locator syntax is explained in `Item locators`.
         """
         label = self.state._get_typed_item_by_locator(Label, locator)

--- a/src/WhiteLibrary/keywords/items/label.py
+++ b/src/WhiteLibrary/keywords/items/label.py
@@ -8,7 +8,7 @@ class LabelKeywords(LibraryComponent):
     def verify_label(self, locator, expected):
         """Verifies text of a label.
 
-        ``locator`` is the locator of the label or item with type Label.
+        ``locator`` is the locator of the label or Label item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected text.
@@ -20,7 +20,7 @@ class LabelKeywords(LibraryComponent):
     def get_text_from_label(self, locator):
         """Returns the text of a label.
 
-        ``locator`` is the locator of the label or item with type Label.
+        ``locator`` is the locator of the label or Label item object.
         Locator syntax is explained in `Item locators`.
         """
         label = self.state._get_typed_item_by_locator(Label, locator)

--- a/src/WhiteLibrary/keywords/items/listcontrols.py
+++ b/src/WhiteLibrary/keywords/items/listcontrols.py
@@ -9,7 +9,7 @@ class ListKeywords(LibraryComponent):
     def select_listbox_value(self, locator, value):
         """Selects a value from a listbox.
 
-        ``locator`` is the locator of the listbox.
+        ``locator`` is the locator of the listbox or item with type ListBox.
         Locator syntax is explained in `Item locators`.
 
         ``value`` is the value to be selected.
@@ -21,7 +21,7 @@ class ListKeywords(LibraryComponent):
     def select_listbox_index(self, locator, item_index):
         """Selects an item by its index from a listbox.
 
-        ``locator`` is the locator of the listbox.
+        ``locator`` is the locator of the listbox or item with type ListBox.
         Locator syntax is explained in `Item locators`.
 
         ``item_index`` is the index of the item to select.
@@ -35,7 +35,7 @@ class ListKeywords(LibraryComponent):
 
         Fails if the selection was not as expected.
 
-        ``locator`` is the locator of the listbox.
+        ``locator`` is the locator of the listbox or item with type ListBox.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected selection value.
@@ -49,7 +49,7 @@ class ListKeywords(LibraryComponent):
     def select_combobox_value(self, locator, value):
         """Selects a value from a combobox.
 
-        ``locator`` is the locator of the combobox.
+        ``locator`` is the locator of the combobox or item with type ComboBox.
         Locator syntax is explained in `Item locators`.
 
         ``value`` is the value to be selected.
@@ -62,7 +62,7 @@ class ListKeywords(LibraryComponent):
         """
         Selects a value from combobox by using its index.
 
-        ``locator`` is the locator of the combobox.
+        ``locator`` is the locator of the combobox or item with type ComboBox.
         Locator syntax is explained in `Item locators`.
 
         ``item_index`` is the index to be selected.
@@ -75,7 +75,7 @@ class ListKeywords(LibraryComponent):
         """*DEPRECATED* Please use Verify Combobox Selection instead
         Verifies the selected value of a combobox.
 
-        ``locator`` is the locator of the combobox.
+        ``locator`` is the locator of the combobox or item with type ComboBox.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected selection value.
@@ -86,7 +86,7 @@ class ListKeywords(LibraryComponent):
     def verify_combobox_selection(self, locator, expected):
         """Verifies that the combobox value is selected.
 
-        ``locator`` is the locator of the combobox.
+        ``locator`` is the locator of the combobox or item with type ComboBox.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected selection value.

--- a/src/WhiteLibrary/keywords/items/listcontrols.py
+++ b/src/WhiteLibrary/keywords/items/listcontrols.py
@@ -9,7 +9,7 @@ class ListKeywords(LibraryComponent):
     def select_listbox_value(self, locator, value):
         """Selects a value from a listbox.
 
-        ``locator`` is the locator of the listbox or item with type ListBox.
+        ``locator`` is the locator of the listbox or ListBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``value`` is the value to be selected.
@@ -21,7 +21,7 @@ class ListKeywords(LibraryComponent):
     def select_listbox_index(self, locator, item_index):
         """Selects an item by its index from a listbox.
 
-        ``locator`` is the locator of the listbox or item with type ListBox.
+        ``locator`` is the locator of the listbox or ListBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``item_index`` is the index of the item to select.
@@ -35,7 +35,7 @@ class ListKeywords(LibraryComponent):
 
         Fails if the selection was not as expected.
 
-        ``locator`` is the locator of the listbox or item with type ListBox.
+        ``locator`` is the locator of the listbox or ListBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected selection value.
@@ -49,7 +49,7 @@ class ListKeywords(LibraryComponent):
     def select_combobox_value(self, locator, value):
         """Selects a value from a combobox.
 
-        ``locator`` is the locator of the combobox or item with type ComboBox.
+        ``locator`` is the locator of the combobox or ComboBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``value`` is the value to be selected.
@@ -62,7 +62,7 @@ class ListKeywords(LibraryComponent):
         """
         Selects a value from combobox by using its index.
 
-        ``locator`` is the locator of the combobox or item with type ComboBox.
+        ``locator`` is the locator of the combobox or ComboBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``item_index`` is the index to be selected.
@@ -75,7 +75,7 @@ class ListKeywords(LibraryComponent):
         """*DEPRECATED* Please use Verify Combobox Selection instead
         Verifies the selected value of a combobox.
 
-        ``locator`` is the locator of the combobox or item with type ComboBox.
+        ``locator`` is the locator of the combobox or ComboBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected selection value.
@@ -86,7 +86,7 @@ class ListKeywords(LibraryComponent):
     def verify_combobox_selection(self, locator, expected):
         """Verifies that the combobox value is selected.
 
-        ``locator`` is the locator of the combobox or item with type ComboBox.
+        ``locator`` is the locator of the combobox or ComboBox item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected selection value.

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -9,7 +9,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_cell(self, locator, column_name, row_index, x_offset=0, y_offset=0):
         """Double clicks a listview cell.
 
-        ``locator`` is the locator of the listview or item with type ListView.
+        ``locator`` is the locator of the listview or ListView item object.
         Locator syntax is explained in `Item locators`.
 
         ``column_name`` is the name of the column.
@@ -29,7 +29,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
         """Double clicks a listview cell at index.
 
-        ``locator`` is the locator of the listview or item with type ListView.
+        ``locator`` is the locator of the listview or ListView item object.
         Locator syntax is explained in `Item locators`.
 
         ``row_index`` is the zero-based row index.
@@ -49,7 +49,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
         """Double clicks a listview row.
 
-        ``locator`` is the locator of the listview or item with type ListView.
+        ``locator`` is the locator of the listview or ListView item object.
         Locator syntax is explained in `Item locators`.
 
         ``column_name`` and ``cell_text`` define the row. Row is the first matching row where text in column
@@ -68,7 +68,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
         """Double clicks a listview row at index.
 
-        ``locator`` is the locator of the listview or item with type ListView.
+        ``locator`` is the locator of the listview or ListView item object.
         Locator syntax is explained in `Item locators`.
 
         ``row_index`` is the zero-based row index.

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -9,7 +9,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_cell(self, locator, column_name, row_index, x_offset=0, y_offset=0):
         """Double clicks a listview cell.
 
-        ``locator`` is the locator of the listview.
+        ``locator`` is the locator of the listview or item with type ListView.
         Locator syntax is explained in `Item locators`.
 
         ``column_name`` is the name of the column.
@@ -29,7 +29,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_cell_by_index(self, locator, row_index, column_index, x_offset=0, y_offset=0):
         """Double clicks a listview cell at index.
 
-        ``locator`` is the locator of the listview.
+        ``locator`` is the locator of the listview or item with type ListView.
         Locator syntax is explained in `Item locators`.
 
         ``row_index`` is the zero-based row index.
@@ -49,7 +49,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_row(self, locator, column_name, cell_text, x_offset=0, y_offset=0):
         """Double clicks a listview row.
 
-        ``locator`` is the locator of the listview.
+        ``locator`` is the locator of the listview or item with type ListView.
         Locator syntax is explained in `Item locators`.
 
         ``column_name`` and ``cell_text`` define the row. Row is the first matching row where text in column
@@ -68,7 +68,7 @@ class ListViewKeywords(LibraryComponent):
     def double_click_listview_row_by_index(self, locator, row_index, x_offset=0, y_offset=0):
         """Double clicks a listview row at index.
 
-        ``locator`` is the locator of the listview.
+        ``locator`` is the locator of the listview or item with type ListView.
         Locator syntax is explained in `Item locators`.
 
         ``row_index`` is the zero-based row index.

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -9,7 +9,7 @@ class MenuKeywords(LibraryComponent):
     def verify_menu(self, locator, expected):
         """Verifies the text of a menu item.
 
-        ``locator`` is the locator of the menu item or item with type Menu.
+        ``locator`` is the locator of the menu item or Menu item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected text of the menu item.
@@ -21,7 +21,7 @@ class MenuKeywords(LibraryComponent):
     def click_menu_button(self, locator, x_offset=0, y_offset=0):
         """Clicks a menu button.
 
-        ``locator`` is the locator of the menu button or item with type Menu.
+        ``locator`` is the locator of the menu button or Menu item object.
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune

--- a/src/WhiteLibrary/keywords/items/menu.py
+++ b/src/WhiteLibrary/keywords/items/menu.py
@@ -9,7 +9,7 @@ class MenuKeywords(LibraryComponent):
     def verify_menu(self, locator, expected):
         """Verifies the text of a menu item.
 
-        ``locator`` is the locator of the menu item.
+        ``locator`` is the locator of the menu item or item with type Menu.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected text of the menu item.
@@ -21,7 +21,7 @@ class MenuKeywords(LibraryComponent):
     def click_menu_button(self, locator, x_offset=0, y_offset=0):
         """Clicks a menu button.
 
-        ``locator`` is the locator of the menu button.
+        ``locator`` is the locator of the menu button or item with type Menu.
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune

--- a/src/WhiteLibrary/keywords/items/mouse.py
+++ b/src/WhiteLibrary/keywords/items/mouse.py
@@ -133,9 +133,9 @@ class MouseKeywords(LibraryComponent):
     def drag_and_drop(self, locator1, locator2):
         """ Drags item with locator ``locator1`` to item with locator ``locator2``.
 
-        ``locator1`` is the locator of the draggable object.
+        ``locator1`` is the locator of the draggable object or draggable item.
 
-        ``locator2`` is the locator of the target for the draggable object.
+        ``locator2`` is the locator of the target for the draggable object or target item itself.
 
         Locator syntax is explained in `Item locators`.
         """

--- a/src/WhiteLibrary/keywords/items/progressbar.py
+++ b/src/WhiteLibrary/keywords/items/progressbar.py
@@ -8,7 +8,7 @@ class ProgressbarKeywords(LibraryComponent):
     def verify_progressbar_value(self, locator, expected):
         """Verifies the value of a progress bar.
 
-        ``locator`` is the locator of the progress bar.
+        ``locator`` is the locator of the progress bar or item with type ProgressBar.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected value of the progress bar.
@@ -20,7 +20,7 @@ class ProgressbarKeywords(LibraryComponent):
     def get_progressbar_value(self, locator):
         """Returns the value of a progress bar.
 
-        ``locator`` is the locator of the progress bar.
+        ``locator`` is the locator of the progress bar or item with type ProgressBar.
         Locator syntax is explained in `Item locators`.
         """
         progressbar = self.state._get_typed_item_by_locator(ProgressBar, locator)

--- a/src/WhiteLibrary/keywords/items/progressbar.py
+++ b/src/WhiteLibrary/keywords/items/progressbar.py
@@ -8,7 +8,7 @@ class ProgressbarKeywords(LibraryComponent):
     def verify_progressbar_value(self, locator, expected):
         """Verifies the value of a progress bar.
 
-        ``locator`` is the locator of the progress bar or item with type ProgressBar.
+        ``locator`` is the locator of the progress bar or ProgressBar item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected value of the progress bar.
@@ -20,7 +20,7 @@ class ProgressbarKeywords(LibraryComponent):
     def get_progressbar_value(self, locator):
         """Returns the value of a progress bar.
 
-        ``locator`` is the locator of the progress bar or item with type ProgressBar.
+        ``locator`` is the locator of the progress bar or ProgressBar item object.
         Locator syntax is explained in `Item locators`.
         """
         progressbar = self.state._get_typed_item_by_locator(ProgressBar, locator)

--- a/src/WhiteLibrary/keywords/items/slider.py
+++ b/src/WhiteLibrary/keywords/items/slider.py
@@ -8,7 +8,7 @@ class SliderKeywords(LibraryComponent):
     def set_slider_value(self, locator, value):
         """Sets a slider to the specified value.
 
-        ``locator`` is the locator of the slider.
+        ``locator`` is the locator of the slider or item with type Slider.
         Locator syntax is explained in `Item locators`.
 
         ``value`` is the value to set.
@@ -20,7 +20,7 @@ class SliderKeywords(LibraryComponent):
     def verify_slider_value(self, locator, expected):
         """Verifies a slider value.
 
-        ``locator`` is the locator of the slider.
+        ``locator`` is the locator of the slider or item with type Slider.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected value of the slider.
@@ -32,7 +32,7 @@ class SliderKeywords(LibraryComponent):
     def get_slider_value(self, locator):
         """Returns the value of a slider.
 
-        ``locator`` is the locator of the slider.
+        ``locator`` is the locator of the slider or item with type Slider.
         Locator syntax is explained in `Item locators`.
         """
         slider = self.state._get_typed_item_by_locator(Slider, locator)

--- a/src/WhiteLibrary/keywords/items/slider.py
+++ b/src/WhiteLibrary/keywords/items/slider.py
@@ -8,7 +8,7 @@ class SliderKeywords(LibraryComponent):
     def set_slider_value(self, locator, value):
         """Sets a slider to the specified value.
 
-        ``locator`` is the locator of the slider or item with type Slider.
+        ``locator`` is the locator of the slider or Slider item object.
         Locator syntax is explained in `Item locators`.
 
         ``value`` is the value to set.
@@ -20,7 +20,7 @@ class SliderKeywords(LibraryComponent):
     def verify_slider_value(self, locator, expected):
         """Verifies a slider value.
 
-        ``locator`` is the locator of the slider or item with type Slider.
+        ``locator`` is the locator of the slider or Slider item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected value of the slider.
@@ -32,7 +32,7 @@ class SliderKeywords(LibraryComponent):
     def get_slider_value(self, locator):
         """Returns the value of a slider.
 
-        ``locator`` is the locator of the slider or item with type Slider.
+        ``locator`` is the locator of the slider or Slider item object.
         Locator syntax is explained in `Item locators`.
         """
         slider = self.state._get_typed_item_by_locator(Slider, locator)

--- a/src/WhiteLibrary/keywords/items/tab.py
+++ b/src/WhiteLibrary/keywords/items/tab.py
@@ -9,7 +9,7 @@ class TabKeywords(LibraryComponent):
         """
         Selects a tab page.
 
-        ``locator`` is the locator of the tab control item.
+        ``locator`` is the locator of the tab control item or item with type Tab.
         Locator syntax is explained in `Item locators`.
 
         ``title`` is the title of the tab page.

--- a/src/WhiteLibrary/keywords/items/tab.py
+++ b/src/WhiteLibrary/keywords/items/tab.py
@@ -9,7 +9,7 @@ class TabKeywords(LibraryComponent):
         """
         Selects a tab page.
 
-        ``locator`` is the locator of the tab control item or item with type Tab.
+        ``locator`` is the locator of the tab control item or Tab item object.
         Locator syntax is explained in `Item locators`.
 
         ``title`` is the title of the tab page.

--- a/src/WhiteLibrary/keywords/items/textbox.py
+++ b/src/WhiteLibrary/keywords/items/textbox.py
@@ -8,7 +8,7 @@ class TextBoxKeywords(LibraryComponent):
     def input_text_to_textbox(self, locator, input_value):
         """Writes text to a textbox.
 
-        ``locator`` is the locator of the text box or item with type TextBox.
+        ``locator`` is the locator of the text box or Textbox item object.
         Locator syntax is explained in `Item locators`.
 
         ``input_value`` is the text to write.
@@ -20,7 +20,7 @@ class TextBoxKeywords(LibraryComponent):
     def verify_text_in_textbox(self, locator, expected):
         """Verifies text in a text box.
 
-        ``locator`` is the locator of the text box or item with type TextBox.
+        ``locator`` is the locator of the text box or Textbox item object.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected text of the text box.
@@ -32,7 +32,7 @@ class TextBoxKeywords(LibraryComponent):
     def get_text_from_textbox(self, locator):
         """Returns the text of a text box.
 
-        ``locator`` is the locator of the text box or item with type TextBox.
+        ``locator`` is the locator of the text box or Textbox item object.
         Locator syntax is explained in `Item locators`.
         """
         textbox = self.state._get_typed_item_by_locator(TextBox, locator)

--- a/src/WhiteLibrary/keywords/items/textbox.py
+++ b/src/WhiteLibrary/keywords/items/textbox.py
@@ -8,7 +8,7 @@ class TextBoxKeywords(LibraryComponent):
     def input_text_to_textbox(self, locator, input_value):
         """Writes text to a textbox.
 
-        ``locator`` is the locator of the text box.
+        ``locator`` is the locator of the text box or item with type TextBox.
         Locator syntax is explained in `Item locators`.
 
         ``input_value`` is the text to write.
@@ -20,7 +20,7 @@ class TextBoxKeywords(LibraryComponent):
     def verify_text_in_textbox(self, locator, expected):
         """Verifies text in a text box.
 
-        ``locator`` is the locator of the text box.
+        ``locator`` is the locator of the text box or item with type TextBox.
         Locator syntax is explained in `Item locators`.
 
         ``expected`` is the expected text of the text box.
@@ -32,7 +32,7 @@ class TextBoxKeywords(LibraryComponent):
     def get_text_from_textbox(self, locator):
         """Returns the text of a text box.
 
-        ``locator`` is the locator of the text box.
+        ``locator`` is the locator of the text box or item with type TextBox.
         Locator syntax is explained in `Item locators`.
         """
         textbox = self.state._get_typed_item_by_locator(TextBox, locator)

--- a/src/WhiteLibrary/keywords/items/tree.py
+++ b/src/WhiteLibrary/keywords/items/tree.py
@@ -8,7 +8,7 @@ class TreeKeywords(LibraryComponent):
     def select_tree_node(self, locator, *node_path):
         """Selects a tree node.
 
-        ``locator`` is the locator of the tree or item with type Tree.
+        ``locator`` is the locator of the tree or Tree item object.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to select.
@@ -34,7 +34,7 @@ class TreeKeywords(LibraryComponent):
     def expand_tree_node(self, locator, *node_path):
         """Expands a tree node.
 
-        ``locator`` is the locator of the tree or item with type Tree.
+        ``locator`` is the locator of the tree or Tree item object.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to expand.
@@ -48,7 +48,7 @@ class TreeKeywords(LibraryComponent):
     def double_click_tree_node(self, locator, *node_path):
         """Double-clicks a tree node.
 
-        ``locator`` is the locator of the tree or item with type Tree.
+        ``locator`` is the locator of the tree or Tree item object.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to double-click.
@@ -62,7 +62,7 @@ class TreeKeywords(LibraryComponent):
     def right_click_tree_node(self, locator, *node_path):
         """Right-clicks a tree node.
 
-        ``locator`` is the locator of the tree or item with type Tree.
+        ``locator`` is the locator of the tree or Tree item object.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to right-click.

--- a/src/WhiteLibrary/keywords/items/tree.py
+++ b/src/WhiteLibrary/keywords/items/tree.py
@@ -8,7 +8,7 @@ class TreeKeywords(LibraryComponent):
     def select_tree_node(self, locator, *node_path):
         """Selects a tree node.
 
-        ``locator`` is the locator of the tree.
+        ``locator`` is the locator of the tree or item with type Tree.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to select.
@@ -34,7 +34,7 @@ class TreeKeywords(LibraryComponent):
     def expand_tree_node(self, locator, *node_path):
         """Expands a tree node.
 
-        ``locator`` is the locator of the tree.
+        ``locator`` is the locator of the tree or item with type Tree.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to expand.
@@ -48,7 +48,7 @@ class TreeKeywords(LibraryComponent):
     def double_click_tree_node(self, locator, *node_path):
         """Double-clicks a tree node.
 
-        ``locator`` is the locator of the tree.
+        ``locator`` is the locator of the tree or item with type Tree.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to double-click.
@@ -62,7 +62,7 @@ class TreeKeywords(LibraryComponent):
     def right_click_tree_node(self, locator, *node_path):
         """Right-clicks a tree node.
 
-        ``locator`` is the locator of the tree.
+        ``locator`` is the locator of the tree or item with type Tree.
         Locator syntax is explained in `Item locators`.
 
         ``node_path`` is the path the to node to right-click.

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -9,7 +9,7 @@ class UiItemKeywords(LibraryComponent):
     def click_item(self, locator, x_offset=0, y_offset=0):
         """Clicks an item.
 
-        ``locator`` is the locator of the item.
+        ``locator`` is the locator of the item or object of an item.
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
@@ -22,7 +22,7 @@ class UiItemKeywords(LibraryComponent):
     def right_click_item(self, locator, x_offset=0, y_offset=0):
         """Right clicks an item.
 
-        ``locator`` is the locator of the item.
+        ``locator`` is the locator of the item or object of an item.
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune
@@ -35,7 +35,7 @@ class UiItemKeywords(LibraryComponent):
     def double_click_item(self, locator, x_offset=0, y_offset=0):
         """Double clicks an item.
 
-        ``locator`` is the locator of the item.
+        ``locator`` is the locator of the item or object of an item.
         Locator syntax is explained in `Item locators`.
 
         Optional arguments ``x_offset`` and ``y_offset`` can be used to fine tune


### PR DESCRIPTION
Item related keywords like Click Button, Click Item can now be used with item reference i.e.
    ${item}=    Get Item    mybutton
    Click Button    ${item}

Closes #104 