### PR TITLE
Partial text locator

### DIFF
--- a/atests/feature_tests/locators.robot
+++ b/atests/feature_tests/locators.robot
@@ -51,7 +51,10 @@ List UI Items
     ${items}    Get Items    control_type=Button
     ${count}    Get Length    ${items}
     Should Be True    ${count} > 1
+    ${items}    Get Items    partial_text:a
+    ${count}    Get Length    ${items}
+    Should Be True    ${count} > 1
 
-Unexisting Locator
+Unexisting Locators
     ${error}    Run Keyword And Expect Error    *    Click Item    unexisting-locator=whatever
     Should Contain    ${error}    'unexisting-locator' is not a valid locator prefix

--- a/atests/feature_tests/locators.robot
+++ b/atests/feature_tests/locators.robot
@@ -4,10 +4,9 @@ Library    String
 Library    WhiteLibrary
 Test Setup    Attach Main Window
 Test Teardown    Clean Application
-Resource          ..${/}resource.robot
+Resource    ../resource.robot
 
 *** Test Cases ***
-
 Calculate Using Index Locators
     Input Text To Textbox    index=0    1
     Select Combobox Value    index=0    +
@@ -28,6 +27,13 @@ Calculate Using Native Property Locators
     Input Text To Textbox    help_text=Second addend    21
     Click Button    btnCalc
     Verify Text In Textbox    help_text=Sum    33
+
+Calculate Using Partial Text
+    Input Text To Textbox    partial_text:alc1    1
+    Select Combobox Value    index:0    +
+    Input Text To Textbox    index:2    2
+    Click Button    partial_text:Calcul
+    Verify Text In Textbox    index:3    3
 
 Click Button With = In Locator Value
     Input Text To Textbox    txtA    1

--- a/atests/feature_tests/locators.robot
+++ b/atests/feature_tests/locators.robot
@@ -58,3 +58,5 @@ List UI Items
 Unexisting Locators
     ${error}    Run Keyword And Expect Error    *    Click Item    unexisting-locator=whatever
     Should Contain    ${error}    'unexisting-locator' is not a valid locator prefix
+    ${error}    Run Keyword And Expect Error    *    Click Item    partial_text:this-does-not-exist
+    Should Contain    ${error}    Item with locator 'partial_text:this-does-not-exist' was not found

--- a/atests/feature_tests/locators.robot
+++ b/atests/feature_tests/locators.robot
@@ -59,4 +59,4 @@ Unexisting Locators
     ${error}    Run Keyword And Expect Error    *    Click Item    unexisting-locator=whatever
     Should Contain    ${error}    'unexisting-locator' is not a valid locator prefix
     ${error}    Run Keyword And Expect Error    *    Click Item    partial_text:this-does-not-exist
-    Should Contain    ${error}    Item with locator 'partial_text:this-does-not-exist' was not found
+    Should Contain    ${error}    Item with partial text 'this-does-not-exist' was not found

--- a/atests/feature_tests/wait.robot
+++ b/atests/feature_tests/wait.robot
@@ -24,6 +24,7 @@ Successful Wait Until Item With Partial Text Exists
     Click And Wait For Fast Alert
     Click Slow Alert
     Wait Until Item Exists    partial_text:Slow al    7 seconds
+    [Teardown]    Wait Until Item Exists     ${SLOW_ALERT}    6 seconds
 
 Failing Wait Until Item Exists
     Click And Wait For Fast Alert

--- a/atests/feature_tests/wait.robot
+++ b/atests/feature_tests/wait.robot
@@ -20,6 +20,11 @@ Successful Wait Until Item Does Not Exist
     Click Slow Alert
     Wait Until Item Does Not Exist    ${FAST_ALERT}    6 seconds
 
+Successful Wait Until Item With Partial Text Exists
+    Click And Wait For Fast Alert
+    Click Slow Alert
+    Wait Until Item Exists    partial_text:Slow al    7 seconds
+
 Failing Wait Until Item Exists
     Click And Wait For Fast Alert
     Click Slow Alert

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 robotframework
-pythonnet; sys.platform == 'win32'
+pythonnet>=2.4.0; sys.platform == 'win32'

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -215,7 +215,7 @@ class WhiteLibrary(DynamicCore):
                 return next(items)
             return next((item for item in items if (item.GetType() == clr.GetClrType(item_type))))
         except StopIteration:
-            raise ItemNotFoundError(u"Item with locator 'partial_text:{}' was not found".format(partial_text))
+            raise ItemNotFoundError(u"Item with partial text '{}' was not found".format(partial_text))
 
     def _get_multiple_items_by_partial_text(self, partial_text):
         items = self.window.GetMultiple(SearchCriteria.All)

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -1,7 +1,6 @@
 # pylint: disable=invalid-name
 import os
 from robot.utils import is_truthy
-from robot.api import logger
 import clr
 DLL_PATH = os.path.join(os.path.dirname(os.path.abspath(__file__)), 'bin', 'TestStack.White.dll')
 clr.AddReference('System')
@@ -214,7 +213,8 @@ class WhiteLibrary(DynamicCore):
         except StopIteration:
             raise ValueError("not found")  # replace with same exception type as white uses when not found
 
-    def _get_search_criteria(self, search_strategy, locator_value):
+    @staticmethod
+    def _get_search_criteria(search_strategy, locator_value):
         if search_strategy == "index":
             locator_value = int(locator_value)
 

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -202,19 +202,20 @@ class WhiteLibrary(DynamicCore):
         search_strategy, locator_value = self._parse_locator(locator)
 
         if search_strategy == "partial_text":
-            return list(self._get_multiple_items_by_partial_text(locator))
+            return list(self._get_multiple_items_by_partial_text(locator_value))
 
         search_criteria = self._get_search_criteria(search_strategy, locator_value)
         return self.window.GetMultiple(search_criteria)
 
     def _get_item_by_partial_text(self, partial_text, item_type=None):
-        return next(self._get_multiple_items_by_partial_text(partial_text, item_type), None)
+        items = self._get_multiple_items_by_partial_text(partial_text)
+        if item_type is None:
+            return next(items, None)
+        return next((item for item in items if (item.GetType() == clr.GetClrType(item_type))), None)
 
-    def _get_multiple_items_by_partial_text(self, partial_text, item_type=None):
+    def _get_multiple_items_by_partial_text(self, partial_text):
         items = self.window.GetMultiple(SearchCriteria.All)
-        if item_type is not None:
-            items = (i for i in items if (i.GetType() == clr.GetClrType(item_type)))
-        return (i for i in items if partial_text in i.Name)
+        return (item for item in items if partial_text in item.Name)
 
     @staticmethod
     def _get_search_criteria(search_strategy, locator_value):

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -23,6 +23,7 @@ from WhiteLibrary.keywords.items import (ButtonKeywords,
                                          TextBoxKeywords,
                                          UiItemKeywords)   # noqa: E402
 from WhiteLibrary.keywords.robotlibcore import DynamicCore   # noqa: E402
+from WhiteLibrary.errors import ItemNotFoundError   # noqa: E402
 from WhiteLibrary import version   # noqa: E402
 
 
@@ -209,9 +210,12 @@ class WhiteLibrary(DynamicCore):
 
     def _get_item_by_partial_text(self, partial_text, item_type=None):
         items = self._get_multiple_items_by_partial_text(partial_text)
-        if item_type is None:
-            return next(items, None)
-        return next((item for item in items if (item.GetType() == clr.GetClrType(item_type))), None)
+        try:
+            if item_type is None:
+                return next(items)
+            return next((item for item in items if (item.GetType() == clr.GetClrType(item_type))))
+        except StopIteration:
+            raise ItemNotFoundError(u"Item with locator 'partial_text:{}' was not found".format(partial_text))
 
     def _get_multiple_items_by_partial_text(self, partial_text):
         items = self.window.GetMultiple(SearchCriteria.All)

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -200,18 +200,21 @@ class WhiteLibrary(DynamicCore):
 
     def _get_multiple_items_by_locator(self, locator):
         search_strategy, locator_value = self._parse_locator(locator)
+
+        if search_strategy == "partial_text":
+            return list(self._get_multiple_items_by_partial_text(locator))
+
         search_criteria = self._get_search_criteria(search_strategy, locator_value)
         return self.window.GetMultiple(search_criteria)
 
     def _get_item_by_partial_text(self, partial_text, item_type=None):
-        return next(self._get_multiple_items_by_partial_text(partial_text, item_type))
+        return next(self._get_multiple_items_by_partial_text(partial_text, item_type), None)
 
     def _get_multiple_items_by_partial_text(self, partial_text, item_type=None):
         items = self.window.GetMultiple(SearchCriteria.All)
-        try:
-            return (i for i in items if (i.GetType() == clr.GetClrType(item_type)) and (partial_text in i.Name))
-        except StopIteration:
-            raise ValueError("not found")  # replace with same exception type as white uses when not found
+        if item_type is not None:
+            items = (i for i in items if (i.GetType() == clr.GetClrType(item_type)))
+        return (i for i in items if partial_text in i.Name)
 
     @staticmethod
     def _get_search_criteria(search_strategy, locator_value):

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -213,7 +213,7 @@ class WhiteLibrary(DynamicCore):
         try:
             if item_type is None:
                 return next(items)
-            return next((item for item in items if (item.GetType() == clr.GetClrType(item_type))))
+            return next((item for item in items if item.GetType() == clr.GetClrType(item_type)))
         except StopIteration:
             raise ItemNotFoundError(u"Item with partial text '{}' was not found".format(partial_text))
 

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -177,28 +177,34 @@ class WhiteLibrary(DynamicCore):
             if not isinstance(locator, item_type):
                 raise TypeError("Item object was not of the expected type")
             return locator
+
         search_strategy, locator_value = self._parse_locator(locator)
+
         if search_strategy == "partial_text":
             return self._get_item_by_partial_text(locator_value, item_type)
+
         search_criteria = self._get_search_criteria(search_strategy, locator_value)
         return self.window.Get[item_type](search_criteria)
 
     def _get_item_by_locator(self, locator):
         if isinstance(locator, UIItem):
             return locator
+
         search_strategy, locator_value = self._parse_locator(locator)
+
         if search_strategy == "partial_text":
             return self._get_item_by_partial_text(locator_value)
+
         search_criteria = self._get_search_criteria(search_strategy, locator_value)
         return self.window.Get(search_criteria)
-
-    def _get_item_by_partial_text(self, partial_text, item_type=None):
-        return next(self._get_multiple_items_by_partial_text(partial_text, item_type))
 
     def _get_multiple_items_by_locator(self, locator):
         search_strategy, locator_value = self._parse_locator(locator)
         search_criteria = self._get_search_criteria(search_strategy, locator_value)
         return self.window.GetMultiple(search_criteria)
+
+    def _get_item_by_partial_text(self, partial_text, item_type=None):
+        return next(self._get_multiple_items_by_partial_text(partial_text, item_type))
 
     def _get_multiple_items_by_partial_text(self, partial_text, item_type=None):
         items = self.window.GetMultiple(SearchCriteria.All)

--- a/src/WhiteLibrary/__init__.py
+++ b/src/WhiteLibrary/__init__.py
@@ -79,6 +79,7 @@ class WhiteLibrary(DynamicCore):
     | help_text         | Search by HelpTextProperty.        |
     | class_name        | Search by class name.              |
     | control_type      | Search by control type.            |
+    | partial_text      | Search by text that the item text/name contains. |
 
     Examples:
     | `Click Button` | myButton         | # clicks button by its AutomationID |

--- a/src/WhiteLibrary/errors.py
+++ b/src/WhiteLibrary/errors.py
@@ -1,0 +1,2 @@
+class ItemNotFoundError(Exception):
+    pass

--- a/src/WhiteLibrary/keywords/items/toolstrip.py
+++ b/src/WhiteLibrary/keywords/items/toolstrip.py
@@ -17,7 +17,7 @@ class ToolStripKeywords(LibraryComponent):
 
     def _get_toolstrip_button_by_index(self, locator, index):
         toolstrip = self.state._get_typed_item_by_locator(ToolStrip, locator)
-        search_criteria = self.state._get_search_criteria("control_type:Button")
+        search_criteria = self.state._get_search_criteria("control_type", "Button")
         try:
             return toolstrip.GetMultiple(search_criteria)[index]
         except IndexError:

--- a/src/WhiteLibrary/keywords/items/uiitem.py
+++ b/src/WhiteLibrary/keywords/items/uiitem.py
@@ -122,5 +122,8 @@ class UiItemKeywords(LibraryComponent):
                         .format(locator, timestr_to_secs(timeout)))
 
     def _item_exists(self, locator):
-        search_criteria = self.state._get_search_criteria(locator)
+        search_strategy, locator_value = self.state._parse_locator(locator)
+        if search_strategy == "partial_text":
+            return any(locator_value in item.Name for item in self.state.window.Items)
+        search_criteria = self.state._get_search_criteria(search_strategy, locator_value)
         return self.state.window.Exists(search_criteria)


### PR DESCRIPTION
New partial_text locator type that allows searching for items that contain a certain text in their text/name.

- [x] More tests
- [x] Improve error message when item not found

Requires pythonnet>=2.4.0 because clr.GetClrType() is new in 2.4.0.