### PR TITLE
New keywords for ListView rows

### DIFF
--- a/atests/feature_tests/items.robot
+++ b/atests/feature_tests/items.robot
@@ -252,23 +252,23 @@ Try To Press Unsupported Special Key
 Handle Tree Nodes
     [Setup]    Setup for Tab 2 Tests
     Select Tree Node    tree    @{Tree node 1}
-    Selction Indicator Should Be     Tree node 1     Selected
+    Selection Indicator Should Be     Tree node 1     Selected
     Expand Tree Node    tree    @{Tree node 1}
-    Selction Indicator Should Be    Tree node 1     Expanded
+    Selection Indicator Should Be    Tree node 1     Expanded
     Double Click Tree Node    tree    @{Tree node 1}
-    Selction Indicator Should Be    Tree node 1    Double-clicked
+    Selection Indicator Should Be    Tree node 1    Double-clicked
     Right Click Tree Node    tree    @{Tree node 1.1}
-    Selction Indicator Should Be    Tree node 1.1    Right-clicked
+    Selection Indicator Should Be    Tree node 1.1    Right-clicked
     [Teardown]    Select Tab Page    tabControl    Tab1
 
 Handle ToolStripButtons
     [Setup]    Setup for Tab 2 Tests
     Click Button    text=Toolstrip button 1
-    Selction Indicator Should Be    Toolstrip button 1     Clicked
+    Selection Indicator Should Be    Toolstrip button 1     Clicked
     Click Button    text=Toolstrip button 2
-    Selction Indicator Should Be     Toolstrip button 2     Clicked
+    Selection Indicator Should Be     Toolstrip button 2     Clicked
     Click Button    text=Toolstrip button 3
-    Selction Indicator Should Be    Toolstrip button 3    Clicked
+    Selection Indicator Should Be    Toolstrip button 3    Clicked
     [Teardown]    Select Tab Page    tabControl    Tab1
 
 Popup menu with subitems

--- a/atests/feature_tests/listview.robot
+++ b/atests/feature_tests/listview.robot
@@ -74,42 +74,48 @@ Get Text From ListView
 
 Select Listview Row
     Select ListView Row By Index    birds    1
-    Selction Indicator Should Be     Row 1    Selected
+    Selection Indicator Should Be     Row 1    Selected
     Select ListView Row By Index    list_view    2
-    Selction Indicator Should Be    Row 2     Selected
+    Selection Indicator Should Be    Row 2     Selected
     Select ListView Row    list_view    Title    Robinson Crusoe
-    Selction Indicator Should Be    Row 0     Selected
+    Selection Indicator Should Be    Row 0     Selected
+    Select Listview Row By Text    list_view    The Art of Computer Programming
+    Selection Indicator Should Be     Row 2     Selected
 
 Select Listview Cell
     Select Listview Cell    list_view2    Author    1
-    Selction Indicator Should Be    Various Artists     Selected
+    Selection Indicator Should Be    Various Artists     Selected
     Select Listview Cell By Index    list_view2    2    2
-    Selction Indicator Should Be    Science    Selected
+    Selection Indicator Should Be    Science    Selected
 
 Right Click Listview Row
     # click twice because first click selects the row
     Repeat Keyword    2    Right Click Listview Row    birds    Bird    Dodo
-    Selction Indicator Should Be     Row 2     Right Clicked
+    Selection Indicator Should Be     Row 2     Right Clicked
     Repeat Keyword    2    Right Click Listview Row By Index    birds    0
-    Selction Indicator Should Be    Row 0     Right Clicked
+    Selection Indicator Should Be    Row 0     Right Clicked
+    Repeat Keyword    2    Right Click Listview Row By Text    birds    Varpuspöllö
+    Selection Indicator Should Be     Row 3     Right Clicked
 
 Right Click Listview Cell
     Repeat Keyword    2    Right Click Listview Cell    list_view2    Title    1
-    Selction Indicator Should Be    Bible     Right Clicked
+    Selection Indicator Should Be    Bible     Right Clicked
     Repeat Keyword    2    Right Click Listview Cell By Index    list_view2    0    0
-    Selction Indicator Should Be    Daniel Defoe     Right Clicked
+    Selection Indicator Should Be    Daniel Defoe     Right Clicked
 
 Double Click Listview Row
     Double Click ListView Row    birds    Bird    Dodo
-    Selction Indicator Should Be    Row 2     Double Clicked
+    Selection Indicator Should Be    Row 2     Double Clicked
     Double Click ListView Row By Index    birds    1
-    Selction Indicator Should Be    Row 1     Double Clicked
+    Selection Indicator Should Be    Row 1     Double Clicked
+    Double Click Listview Row By Text    list_view    The Art of Computer Programming
+    Selection Indicator Should Be    Row 2    Double Clicked
 
 Double Click Listview Cell
     Double Click Listview Cell    list_view2    Author    2
-    Selction Indicator Should Be    Donald Knuth    Double Clicked
+    Selection Indicator Should Be    Donald Knuth    Double Clicked
     Double Click Listview Cell By Index    list_view2    0    2
-    Selction Indicator Should Be    Fiction    Double Clicked
+    Selection Indicator Should Be    Fiction    Double Clicked
 
 Listview Row With Non-Ascii Chars
     Run Keyword And Expect Error    Cell did not contain text 'pölö'

--- a/atests/resource.robot
+++ b/atests/resource.robot
@@ -3,17 +3,15 @@ Library    String
 Library    WhiteLibrary
 
 *** Variables ***
-${TEST APPLICATION}      ${EXECDIR}${/}UIAutomationTest${/}bin${/}Debug${/}UIAutomationTest.exe
-${DELAYED TEST APPLICATION}      ${EXECDIR}${/}UIAutomationTest${/}delayed_start.bat
+${TEST APPLICATION}      ${EXECDIR}/UIAutomationTest/bin/Debug/UIAutomationTest.exe
+${DELAYED TEST APPLICATION}      ${EXECDIR}/UIAutomationTest/delayed_start.bat
 ${TEST APPLICATION NAME}    UIAutomationTest
 ${INVALID TEST APPLICATION NAME}    UIAutomationTestThatDoesNotExist
 ${TEST APPLICATION WINDOW TITLE}    UI Automation Test Window
-${TEST WHITE APPLICATION}      ${EXECDIR}${/}WhiteTestApp${/}WpfTestApplication.exe
+${TEST WHITE APPLICATION}      ${EXECDIR}/WhiteTestApp/WpfTestApplication.exe
 ${TEST WHITE APPLICATION NAME}    MainWindow
 
-
 *** Keywords ***
-
 Launch Application For Test
     [Arguments]    ${args}=${EMPTY}
     Set Log Level    Info
@@ -43,7 +41,7 @@ Setup For Tab 2 Tests
     Attach Main Window
     Select Tab Page    tabControl    Tab2
 
-Selction Indicator Should Be
+Selection Indicator Should Be
     [Arguments]    ${node label}    ${status}
     [Documentation]    Note that node label is case sensitive
     ${status}=    Convert To Lowercase    ${status}

--- a/src/WhiteLibrary/keywords/items/listview.py
+++ b/src/WhiteLibrary/keywords/items/listview.py
@@ -83,6 +83,25 @@ class ListViewKeywords(LibraryComponent):
         Clicks.double_click(row, x_offset, y_offset)
 
     @keyword
+    def double_click_listview_row_by_text(self, locator, text, x_offset=0, y_offset=0):
+        """Double clicks a listview row with matching text.
+
+        ``locator`` is the locator of the listview or the ListView item object.
+        Locator syntax is explained in `Item locators`.
+
+        ``text`` is the exact text of the row. If there are multiple cells on the row, the text will be matched
+        against the first cell.
+
+        Optional arguments ``x_offset`` and ``y_offset`` can be used to define the coordinates to click at,
+        relative to the center of the item.
+
+        Example:
+        | Double Click Listview Row By Text | id:cities | Berlin |
+        """
+        row = self._get_row_by_text(locator, text)
+        Clicks.double_click(row, x_offset, y_offset)
+
+    @keyword
     def get_listview_cell_text(self, locator, column_name, row_index):
         """Returns text of a listview cell.
 
@@ -296,6 +315,15 @@ class ListViewKeywords(LibraryComponent):
         Clicks.right_click(row, x_offset, y_offset)
 
     @keyword
+    def right_click_listview_row_by_text(self, locator, text, x_offset=0, y_offset=0):
+        """Right clicks a listview row with matching text.
+
+        See `Double Click Listview Row By Text` for details about arguments ``locator`` and ``text``.
+        """
+        row = self._get_row_by_text(locator, text)
+        Clicks.right_click(row, x_offset, y_offset)
+
+    @keyword
     def select_listview_cell(self, locator, column_name, row_index):
         """Selects a listview cell.
 
@@ -331,6 +359,15 @@ class ListViewKeywords(LibraryComponent):
         listview = self.state._get_typed_item_by_locator(ListView, locator)
         listview.Select(int(row_index))
 
+    @keyword
+    def select_listview_row_by_text(self, locator, text):
+        """Selects a listview row with matching text.
+
+        See `Double Click Listview Row By Text` for details about arguments ``locator`` and ``text``.
+        """
+        row = self._get_row_by_text(locator, text)
+        row.Select()
+
     def _get_row(self, locator, column_name, cell_text):
         listview = self.state._get_typed_item_by_locator(ListView, locator)
         return listview.Rows.Get(column_name, cell_text)
@@ -338,6 +375,10 @@ class ListViewKeywords(LibraryComponent):
     def _get_row_by_index(self, locator, index):
         listview = self.state._get_typed_item_by_locator(ListView, locator)
         return listview.Rows.Get(int(index))
+
+    def _get_row_by_text(self, locator, text):
+        listview = self.state._get_typed_item_by_locator(ListView, locator)
+        return next((row for row in listview.Rows if row.Cells[0].Text == text), None)
 
     def _get_cell(self, locator, column_name, row_index):
         listview = self.state._get_typed_item_by_locator(ListView, locator)


### PR DESCRIPTION
New keywords: 
- `Select Listview Row By Text`
- `Double Click Listview Row By Text` 
- `Right Click Listview Row By Text` 

Keywords search for a row where the first cell has the given text (= row text in one-column list views).